### PR TITLE
Automated cloudwatch alarms. Includes:

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,4 +33,3 @@ suites:
   - name: set-timezone
     run_list:
       - recipe[mh-opsworks-recipes::set-timezone]
-

--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,7 @@ source "https://supermarket.chef.io"
 
 cookbook 'nfs', '~> 2.1.0'
 cookbook 'apt'
+cookbook 'awscli', '~> 1.0.1'
+cookbook 'cron', '~> 1.6.1'
 
 metadata

--- a/files/default/custom_metrics_shared.sh
+++ b/files/default/custom_metrics_shared.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+namespace="AWS/OpsworksCustom"
+# ec2metadata is installed by the aws cloud-init process. Hopefully
+# it doesn't change name or functionality any time soon.
+# This will have problems when deployed to availability zones
+# that don't match their region plus another character.
+availability=$(ec2metadata --availability-zone)
+region=${availability:0:${#availability} -1}

--- a/files/default/disk_free_metric.sh
+++ b/files/default/disk_free_metric.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. /usr/local/bin/custom_metrics_shared.sh
+
+instance_id="$1"
+metric_name=""
+
+local_file_systems=$(mount | grep -E 'type ext|type xfs' | cut -f3 -d' ')
+
+for partition_mount in $local_file_systems; do
+  if [ $partition_mount = '/' ]; then
+    metric_name="SpaceFreeOnRootPartition"
+  else
+    metric_suffix=$(echo -n "$partition_mount" | tr -c "[[:alnum:]]" "_")
+    metric_name="SpaceFreeOn$metric_suffix"
+  fi
+  percent_free=$(expr 100 - $(df -hlP "$partition_mount" | tail -1 | awk '{ print $5 }' | tr -d '/%//'))
+  aws cloudwatch put-metric-data --region="$region" --namespace="$namespace" --dimensions="InstanceId=$instance_id" --metric-name="$metric_name" --value="$percent_free"
+done

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,5 @@ version          '0.1.0'
 
 depends 'nfs', '~> 2.1.0'
 depends 'apt'
+depends 'awscli', '~> 1.0.1'
+depends 'cron', '~> 1.6.1'

--- a/recipes/create-alerts-from-opsworks-metrics.rb
+++ b/recipes/create-alerts-from-opsworks-metrics.rb
@@ -1,0 +1,51 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-alerts-from-opsworks-metrics
+
+include_recipe "awscli::default"
+
+ruby_block "add alarms" do
+  block do
+    # Instance attributes
+    opsworks_instance_id = node[:opsworks][:instance][:id]
+    region = node[:opsworks][:instance][:region]
+    stack_name = node[:opsworks][:stack][:name]
+    hostname = node[:opsworks][:instance][:hostname]
+
+    # Instance properties for monitoring
+    number_of_cpus = %x(nproc).chomp.to_i
+    total_ram = %x(grep MemTotal /proc/meminfo | sed -r 's/[^0-9]//g').chomp.to_i
+    local_file_systems=%x(mount | grep -E 'type ext|type xfs' | cut -f3 -d' ').chomp.split(/\n/)
+
+    topic_name = stack_name.downcase.gsub(/[^a-z\d\-_]/,'_')
+    alarm_name_prefix = %Q|#{topic_name}_#{hostname}|
+
+    # Thresholds for monitoring targets
+    disk_free_threshold = 20
+    memory_limit = total_ram * 0.9
+    load_limit = number_of_cpus * 1.5
+
+    # This is idempotent according to the aws docs
+    topic_arn = %x(aws sns create-topic --name "#{topic_name}" --region #{region} --output text).chomp
+
+    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_load_5_high" --alarm-description "Load 5 is high on #{alarm_name_prefix}" --metric-name load_5 --namespace AWS/OpsWorks --statistic Average --period 300 --threshold #{load_limit} --comparison-operator GreaterThanThreshold --dimensions Name=InstanceId,Value=#{opsworks_instance_id} --evaluation-periods 2 --alarm-actions "#{topic_arn}")
+    Chef::Log.info command
+    %x(#{command})
+
+    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_memory_used_high" --alarm-description "Memory usage is high on #{alarm_name_prefix}" --metric-name memory_used --namespace AWS/OpsWorks --statistic Average --period 300 --threshold #{memory_limit} --comparison-operator GreaterThanThreshold --dimensions Name=InstanceId,Value=#{opsworks_instance_id} --evaluation-periods 2 --alarm-actions "#{topic_arn}")
+    Chef::Log.info command
+    %x(#{command})
+
+    local_file_systems.each do |partition_mount|
+      metric_name = ''
+      if partition_mount == '/'
+        metric_name = 'SpaceFreeOnRootPartition'
+      else
+        metric_suffix = partition_mount.gsub(/[^a-z\d]/,'_')
+        metric_name = "SpaceFreeOn#{metric_suffix}"
+      end
+      command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_#{metric_name}" --alarm-description "#{metric_name} running low on #{alarm_name_prefix}" --metric-name "#{metric_name}" --namespace AWS/OpsworksCustom --statistic Average --period 300 --threshold #{disk_free_threshold} --comparison-operator LessThanThreshold --dimensions Name=InstanceId,Value=#{opsworks_instance_id} --evaluation-periods 2 --alarm-actions "#{topic_arn}")
+      Chef::Log.info command
+      %x(#{command})
+    end
+  end
+end

--- a/recipes/install-custom-metrics.rb
+++ b/recipes/install-custom-metrics.rb
@@ -1,0 +1,34 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-custom-metrics
+
+include_recipe "awscli::default"
+
+opsworks_instance_id = node[:opsworks][:instance][:id]
+
+user "custom_metrics" do
+  comment 'The custom metrics reporting user'
+  system true
+  shell '/bin/false'
+end
+
+cookbook_file "custom_metrics_shared.sh" do
+  path "/usr/local/bin/custom_metrics_shared.sh"
+  owner "root"
+  group "root"
+  mode "755"
+end
+
+cookbook_file "disk_free_metric.sh" do
+  path "/usr/local/bin/disk_free_metric.sh"
+  owner "root"
+  group "root"
+  mode "755"
+end
+
+cron_d 'disk_metrics' do
+  user 'custom_metrics'
+  minute '*/2'
+  # Redirect stderr and stdout to logger. The command is silent on succesful runs
+  command %Q(/usr/local/bin/disk_free_metric.sh "#{opsworks_instance_id}" 2>&1 | logger -t info)
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end

--- a/recipes/remove-alarms.rb
+++ b/recipes/remove-alarms.rb
@@ -1,0 +1,30 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: remove-alarms
+
+ruby_block 'remove alarms for instance' do
+  block do
+    require 'json'
+
+    opsworks_instance_id = node[:opsworks][:instance][:id]
+    region = node[:opsworks][:instance][:region]
+
+    all_alarms = ::JSON.parse(
+      %x(aws cloudwatch describe-alarms --region "#{region}" --output json)
+    )
+
+    alarms_for_instance = all_alarms['MetricAlarms'].find_all do |alarm|
+      alarm['Dimensions'].find do |dimension|
+        dimension['Name'] == 'InstanceId' && dimension['Value'] == opsworks_instance_id
+      end
+    end
+
+    alarm_name_list = alarms_for_instance.map { |alarm| alarm['AlarmName'] }.join(' ')
+    Chef::Log.info alarms_for_instance
+
+    command = %Q(aws cloudwatch delete-alarms --region "#{region}" --alarm-names #{alarm_name_list})
+
+    Chef::Log.info command
+    %x(#{command})
+  end
+end
+


### PR DESCRIPTION
This feature requires that the instance profile for instances it runs on 
allows unfettered access to the cloudwatch service. mh-opsworks creates this
policy by default correctly.

* Install the aws cli interface with the amazon-managed cookbook
* Create alerts for an instance based on the core cloudwatch metrics
* Create and install custom metrics based on instance-specific
 attributes. This creates the "custom_metrics" system user on each
 instance. Custom metrics are reported every two minutes.
* Create an sns topic to catch alarms based on the cluster name
* Monitor instances on load, memory, and free space on local partitions
* Create the "remove-alarms" recipe to remove alarms when an instance is
 shutdown.