### PR TITLE
Implement software RAID monitoring

### DIFF
--- a/files/default/raid_metric.sh
+++ b/files/default/raid_metric.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. /usr/local/bin/custom_metrics_shared.sh
+
+instance_id="$1"
+metric_name="RAIDArrayInSync"
+
+if [ -e "/etc/mdadm/mdadm.conf" ]; then
+  status=1
+  for volume in $(cat /etc/mdadm/mdadm.conf  | grep ARRAY | cut -f 2 -d ' '); do
+    if ! /sbin/mdadm --detail "$volume" -t > /dev/null; then
+      # Detailed status of this volume returned a failure.
+      status=0
+    fi
+  done
+  aws cloudwatch put-metric-data --region="$region" --namespace="$namespace" --dimensions="InstanceId=$instance_id" --metric-name="$metric_name" --value="$status"
+fi

--- a/recipes/create-alerts-from-opsworks-metrics.rb
+++ b/recipes/create-alerts-from-opsworks-metrics.rb
@@ -44,5 +44,12 @@ ruby_block "add alarms" do
       Chef::Log.info command
       %x(#{command})
     end
+
+    if ::File.exists?('/etc/mdadm/mdadm.conf')
+      # Using software raid - add the raid sync metric alarm
+      command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_raid_array_sync" --alarm-description "Software RAID arrays out of sync on #{alarm_name_prefix}" --metric-name RAIDArrayInSync --namespace AWS/OpsworksCustom --statistic Minimum --period 120 --threshold 1 --comparison-operator LessThanThreshold --dimensions Name=InstanceId,Value=#{opsworks_instance_id} --evaluation-periods 1 --alarm-actions "#{topic_arn}" --ok-actions "#{topic_arn}")
+      Chef::Log.info command
+      %x(#{command})
+    end
   end
 end

--- a/recipes/install-custom-metrics.rb
+++ b/recipes/install-custom-metrics.rb
@@ -25,10 +25,25 @@ cookbook_file "disk_free_metric.sh" do
   mode "755"
 end
 
+cookbook_file "raid_metric.sh" do
+  path "/usr/local/bin/raid_metric.sh"
+  owner "root"
+  group "root"
+  mode "755"
+end
+
 cron_d 'disk_metrics' do
   user 'custom_metrics'
   minute '*/2'
   # Redirect stderr and stdout to logger. The command is silent on succesful runs
   command %Q(/usr/local/bin/disk_free_metric.sh "#{opsworks_instance_id}" 2>&1 | logger -t info)
   path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end
+
+cron_d 'raid_metrics' do
+  user 'root'
+  minute '*/2'
+  command %Q(/usr/local/bin/raid_metric.sh "#{opsworks_instance_id}" 2>&1 | logger -t info)
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  only_if { ::File.exists?('/etc/mdadm/mdadm.conf') }
 end


### PR DESCRIPTION
This looks to see if /etc/mdadm/mdadm.conf exists, and if it does it installs:

* The raid metric in a cron job (1 is good, 0 is bad)
* The alarm on the instance where we detected software RAID in use.