### PR TITLE
Allow for forced deployments and rollbacks

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -17,6 +17,17 @@ module MhOpsworksRecipes
       end
     end
 
+    def get_deploy_action
+      valid_actions = %i|deploy force_deploy rollback|
+      requested_action = node.fetch(:deploy_action, :deploy).to_sym
+      Chef::Log.info "requested_action: #{requested_action}"
+      if valid_actions.include?(requested_action)
+        requested_action
+      else
+        :deploy
+      end
+    end
+
     def get_live_stream_name
       node.fetch(:live_stream_name, '#{caName}-#{flavor}.stream-#{resolution}_1_200@')
     end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -44,6 +44,8 @@ include_recipe "mh-opsworks-recipes::create-matterhorn-directories"
 
 allow_matterhorn_user_to_restart_daemon_via_sudo
 
+deploy_action = get_deploy_action
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -58,7 +60,7 @@ deploy_revision matterhorn_repo_root do
   purge_before_symlink([])
   symlink_before_migrate({})
   keep_releases 10
-  action :deploy
+  action deploy_action
 
   before_symlink do
     most_recent_deploy = path_to_most_recent_deploy(new_resource)

--- a/recipes/deploy-database.rb
+++ b/recipes/deploy-database.rb
@@ -17,6 +17,8 @@ database_name = db_info[:database]
 git_data = node[:deploy][:matterhorn][:scm]
 repo_url = git_repo_url(git_data)
 
+deploy_action = get_deploy_action
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -31,7 +33,7 @@ deploy_revision matterhorn_repo_root do
   purge_before_symlink([])
   symlink_before_migrate({})
   keep_releases 10
-  action :deploy
+  action deploy_action
 
   before_symlink do
     most_recent_deploy = path_to_most_recent_deploy(new_resource)

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -52,6 +52,8 @@ include_recipe "mh-opsworks-recipes::create-matterhorn-directories"
 
 allow_matterhorn_user_to_restart_daemon_via_sudo
 
+deploy_action = get_deploy_action
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -66,7 +68,7 @@ deploy_revision matterhorn_repo_root do
   purge_before_symlink([])
   symlink_before_migrate({})
   keep_releases 10
-  action :deploy
+  action deploy_action
 
   before_symlink do
     most_recent_deploy = path_to_most_recent_deploy(new_resource)

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -46,6 +46,8 @@ include_recipe "mh-opsworks-recipes::create-matterhorn-directories"
 
 allow_matterhorn_user_to_restart_daemon_via_sudo
 
+deploy_action = get_deploy_action
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -60,7 +62,7 @@ deploy_revision matterhorn_repo_root do
   purge_before_symlink([])
   symlink_before_migrate({})
   keep_releases 10
-  action :deploy
+  action deploy_action
 
   before_symlink do
     most_recent_deploy = path_to_most_recent_deploy(new_resource)


### PR DESCRIPTION
This allows for the chef deploy resource to get a custom action via custom
json. See the deployment::deploy_app, deployment:redeploy_app and 
deployment:rollback_app rake tasks in mh-opsworks for an implementation 
example.