### PR TITLE
Fully enable enhanced networking on ubuntu 14.04

### DIFF
--- a/files/default/enable_enhanced_networking.sh
+++ b/files/default/enable_enhanced_networking.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+dkms_version=$1
+bucket_name=$2
+
+if modinfo ixgbevf | grep $dkms_version > /dev/null; then
+  echo "already installed ixgbevf $dkms_version"
+  exit 0;
+fi
+
+rm -Rf /root/build_tmp/
+mkdir -p /root/build_tmp
+cd /root/build_tmp
+
+aws s3 cp s3://$bucket_name/ixgbevf-$dkms_version.tar.gz .
+tar zxf ixgbevf-$dkms_version.tar.gz
+mv ixgbevf-$dkms_version /usr/src/
+cd /usr/src/ixgbevf-$dkms_version
+
+echo 'PACKAGE_NAME="ixgbevf"' > /usr/src/"ixgbevf-${dkms_version}"/dkms.conf
+echo "PACKAGE_VERSION=\"${dkms_version}\"" >> /usr/src/"ixgbevf-${dkms_version}"/dkms.conf
+echo '
+CLEAN="cd src/; make clean"
+MAKE="cd src/; make BUILD_KERNEL=${kernelver}"
+BUILT_MODULE_LOCATION[0]="src/"
+BUILT_MODULE_NAME[0]="ixgbevf"
+DEST_MODULE_LOCATION[0]="/updates"
+DEST_MODULE_NAME[0]="ixgbevf"
+AUTOINSTALL="yes"
+' >> /usr/src/"ixgbevf-${dkms_version}"/dkms.conf &&
+
+aws s3 cp s3://$bucket_name/patch-ubuntu_14.04.1-ixgbevf-$dkms_version-kcompat.h.patch .
+cd src
+patch -p5 < ../patch-ubuntu_14.04.1-ixgbevf-$dkms_version-kcompat.h.patch
+dkms add -m ixgbevf -v $dkms_version
+dkms build -m ixgbevf -v $dkms_version
+dkms install -m ixgbevf -v $dkms_version
+update-initramfs -c -k all

--- a/recipes/enable-enhanced-networking.rb
+++ b/recipes/enable-enhanced-networking.rb
@@ -1,0 +1,21 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: enable-enhanced-networking
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+include_recipe "awscli::default"
+install_package('dkms')
+bucket_name = node.fetch(:shared_asset_bucket_name, 'mh-opsworks-shared-assets')
+dkms_version = node.fetch(:ixgbevf_version, "2.16.1")
+
+cookbook_file 'enable_enhanced_networking.sh' do
+  path "/usr/local/bin/enable_enhanced_networking.sh"
+  owner "root"
+  group "root"
+  mode "700"
+end
+
+execute 'fully enable enhanced networking' do
+  # This doesn't do anything if the driver is already the correct version
+  command %Q|/usr/local/bin/enable_enhanced_networking.sh "#{dkms_version}" "#{bucket_name}"|
+end


### PR DESCRIPTION
This will compile and install the driver necessary to get full 10Gbps 
networking.  You must reboot the instance after this recipe runs, which means
a green cluster should ideally be rebooted right after provisioning.

When we switch to a custom AMI, the second reboot will not be necessary. 
Ideally this would be bundled in the default chef recipes.

Includes:

* ixgbevf version 2.16.1 with necessary patches
* Better messaging, use a tmp build directory
* Assets are stored in a bucket that we control
* Ensure the aws-cli is installed