### PR TITLE
Use an asset server when available for external file downloads.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -56,6 +56,17 @@ module MhOpsworksRecipes
       admin_hostname
     end
 
+    def using_asset_server?
+      node[:opsworks][:layers][:asset_server]
+    end
+
+    def get_public_asset_server_hostname
+      if using_asset_server?
+        (private_asset_server_hostname, asset_server_attributes) = node[:opsworks][:layers][:asset_server][:instances].first
+        return asset_server_attributes[:public_dns_name]
+      end
+    end
+
     def get_public_engage_hostname
       return node[:public_engage_hostname] if node[:public_engage_hostname]
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -57,7 +57,7 @@ module MhOpsworksRecipes
     end
 
     def using_asset_server?
-      node[:opsworks][:layers][:asset_server]
+      node[:opsworks][:layers][:asset_server] && node[:opsworks][:layers][:asset_server][:instances].any?
     end
 
     def get_public_asset_server_hostname

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -35,6 +35,8 @@ git_data = node[:deploy][:matterhorn][:scm]
 public_engage_hostname = get_public_engage_hostname
 public_admin_hostname = get_public_admin_hostname_on_admin
 private_hostname = node[:opsworks][:instance][:private_dns_name]
+using_asset_server = using_asset_server?
+asset_server_hostname = get_public_asset_server_hostname
 
 database_connection = node[:deploy][:matterhorn][:database]
 
@@ -101,6 +103,8 @@ deploy_revision matterhorn_repo_root do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_engage_hostname,
+        using_asset_server: using_asset_server,
+        asset_server_hostname: asset_server_hostname,
         cloudfront_url: cloudfront_url,
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -39,6 +39,8 @@ user_tracking_authhost = node.fetch(
 git_data = node[:deploy][:matterhorn][:scm]
 public_engage_hostname = get_public_engage_hostname_on_engage
 private_hostname = node[:opsworks][:instance][:private_dns_name]
+using_asset_server = using_asset_server?
+asset_server_hostname = get_public_asset_server_hostname
 
 public_admin_hostname = get_public_admin_hostname
 
@@ -113,6 +115,8 @@ deploy_revision matterhorn_repo_root do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_engage_hostname,
+        using_asset_server: using_asset_server,
+        asset_server_hostname: asset_server_hostname,
         cloudfront_url: cloudfront_url,
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -35,8 +35,9 @@ git_data = node[:deploy][:matterhorn][:scm]
 
 public_engage_hostname = get_public_engage_hostname
 public_admin_hostname = get_public_admin_hostname
-
 private_hostname = node[:opsworks][:instance][:private_dns_name]
+using_asset_server = using_asset_server?
+asset_server_hostname = get_public_asset_server_hostname
 
 database_connection = node[:deploy][:matterhorn][:database]
 
@@ -107,6 +108,8 @@ deploy_revision matterhorn_repo_root do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_engage_hostname,
+        using_asset_server: using_asset_server,
+        asset_server_hostname: asset_server_hostname,
         cloudfront_url: cloudfront_url,
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,

--- a/templates/default/config.properties.erb
+++ b/templates/default/config.properties.erb
@@ -73,7 +73,9 @@ org.opencastproject.security.demo.loadusers=true
 # ${org.opencastproject.server.url} can not be used, because the streaming server does not use the HTTP protocol.
 # Streaming is not included in the default workflow, since the Red5 streaming server is a 3rd party component that
 # requires separate installation.
-org.opencastproject.streaming.url=rtmp://<%= @engage_hostname %>/matterhorn-engage
+# 
+# NO LONGER USED
+# org.opencastproject.streaming.url=rtmp://some-old-engage-server-maybe/matterhorn-engage
 
 # The directory where the matterhorn streaming app for Red5 stores the streams
 org.opencastproject.streaming.directory=${org.opencastproject.shared_storage.dir}/streams
@@ -84,6 +86,8 @@ org.opencastproject.download.directory=${org.opencastproject.shared_storage.dir}
 # The base URL for media downloads.
 <% if @cloudfront_url %>
 org.opencastproject.download.url=https://<%= @cloudfront_url %>
+<% elsif @using_asset_server %>
+org.opencastproject.download.url=http://<%= @asset_server_hostname %>/static
 <% else %>
 org.opencastproject.download.url=<%= (@using_ssl_for_engage) ? 'https://' : 'http://' %><%= @engage_hostname %>/static
 <% end %>

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -1,6 +1,7 @@
 server {
   listen 80 default_server;
   listen [::]:80 default_server ipv6only=on;
+  directio 1M;
 
   root /usr/share/nginx/html;
   index index.html index.htm;
@@ -30,6 +31,7 @@ server {
 server {
   listen 443 ssl;
   listen [::]:443 ipv6only=on ssl;
+  directio 1M;
 
   root /usr/share/nginx/html;
   index index.html index.htm;


### PR DESCRIPTION
This helps configure matterhorn to use an asset server to seed the CDN origin.
The asset server is a tuned nginx machine that serves large static files
efficiently. Using the asset server to populate the CDN takes significant IO
load off the engage server.

Asset server selection logic:
* If there's a cloudfront_url, use that and emit it from engage.
* If there's a configured asset server, use that. This is now the
 default.
* If there's neither, jpgs and videos are delivered directly from the
 engage node. This is OK for dev clusters.