### PR TITLE
Monitor local matterhorn daemon availability

### DIFF
--- a/files/default/matterhorn_available.sh
+++ b/files/default/matterhorn_available.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. /usr/local/bin/custom_metrics_shared.sh
+
+instance_id="$1"
+matterhorn_port="$2"
+metric_name="MatterhornAvailable"
+test_string="j_username"
+value=0
+if $(/usr/bin/curl -s -L http://localhost/ | grep -q "$test_string"); then
+  value=1
+fi
+
+aws cloudwatch put-metric-data --region="$region" --namespace="$namespace" --dimensions="InstanceId=$instance_id" --metric-name="$metric_name" --value="$value"

--- a/recipes/create-metrics-dependencies.rb
+++ b/recipes/create-metrics-dependencies.rb
@@ -1,0 +1,17 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-metrics-dependencies
+
+include_recipe "awscli::default"
+
+user "custom_metrics" do
+  comment 'The custom metrics reporting user'
+  system true
+  shell '/bin/false'
+end
+
+cookbook_file "custom_metrics_shared.sh" do
+  path "/usr/local/bin/custom_metrics_shared.sh"
+  owner "root"
+  group "root"
+  mode "755"
+end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -3,6 +3,7 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 Chef::Provider::Deploy::Revision.send(:include, MhOpsworksRecipes::DeployHelpers)
+include_recipe "mh-opsworks-recipes::monitor-matterhorn-daemon"
 
 matterhorn_repo_root = node[:matterhorn_repo_root]
 local_workspace_root = get_local_workspace_root

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -3,6 +3,7 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 Chef::Provider::Deploy::Revision.send(:include, MhOpsworksRecipes::DeployHelpers)
+include_recipe "mh-opsworks-recipes::monitor-matterhorn-daemon"
 
 matterhorn_repo_root = node[:matterhorn_repo_root]
 local_workspace_root = get_local_workspace_root

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -3,6 +3,7 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 Chef::Provider::Deploy::Revision.send(:include, MhOpsworksRecipes::DeployHelpers)
+include_recipe "mh-opsworks-recipes::monitor-matterhorn-daemon"
 
 matterhorn_repo_root = node[:matterhorn_repo_root]
 local_workspace_root = get_local_workspace_root

--- a/recipes/install-custom-metrics.rb
+++ b/recipes/install-custom-metrics.rb
@@ -2,22 +2,9 @@
 # Recipe:: install-custom-metrics
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::create-metrics-dependencies"
 
 aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
-
-user "custom_metrics" do
-  comment 'The custom metrics reporting user'
-  system true
-  shell '/bin/false'
-end
-
-cookbook_file "custom_metrics_shared.sh" do
-  path "/usr/local/bin/custom_metrics_shared.sh"
-  owner "root"
-  group "root"
-  mode "755"
-end
 
 cookbook_file "disk_free_metric.sh" do
   path "/usr/local/bin/disk_free_metric.sh"

--- a/recipes/monitor-matterhorn-daemon.rb
+++ b/recipes/monitor-matterhorn-daemon.rb
@@ -1,0 +1,35 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: monitor-matterhorn-daemon
+
+::Chef::Resource::RubyBlock.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe 'mh-opsworks-recipes::create-metrics-dependencies'
+aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
+matterhorn_backend_port = 8080
+
+cookbook_file 'matterhorn_available.sh' do
+  path '/usr/local/bin/matterhorn_available.sh'
+  owner 'root'
+  group 'root'
+  mode '755'
+end
+
+cron_d 'matterhorn_available' do
+  user 'custom_metrics'
+  minute '*/2'
+  # Redirect stderr and stdout to logger. The command is silent on succesful runs
+  command %Q(/usr/local/bin/matterhorn_available.sh "#{aws_instance_id}" "#{matterhorn_backend_port}" 2>&1 | logger -t info)
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end
+
+ruby_block "add matterhorn monitoring" do
+  block do
+    aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
+    region = 'us-east-1'
+    # This is idempotent according to the aws docs
+    topic_arn = %x(aws sns create-topic --name "#{topic_name}" --region #{region} --output text).chomp
+
+    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_matterhorn_availability" --alarm-description "Matterhorn is unavailable #{alarm_name_prefix}" --metric-name MatterhornAvailable --namespace AWS/OpsworksCustom --statistic Minimum --period 120 --threshold 1 --comparison-operator LessThanThreshold --dimensions Name=InstanceId,Value=#{aws_instance_id} --evaluation-periods 1 --alarm-actions "#{topic_arn}" --ok-actions "#{topic_arn}")
+    Chef::Log.info command
+    %x(#{command})
+  end
+end


### PR DESCRIPTION
Includes:

* Install matterhorn monitoring on appropriate instances through the
 deploy recipes
* Look for a test string via cUrl and grep as the test - currently it's
 a very basic test for the login form.