### PR TITLE
Metric and alarms to ensure the NFS mount is available

### DIFF
--- a/files/default/nfs_available.sh
+++ b/files/default/nfs_available.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. /usr/local/bin/custom_metrics_shared.sh
+
+instance_id="$1"
+root_heartbeat_directory="$2"
+metric_name="NFSAvailable"
+value=0
+
+if echo $(/bin/date) > "$root_heartbeat_directory/$instance_id-nfs-heartbeat.txt"; then
+  value=1
+fi
+
+aws cloudwatch put-metric-data --region="$region" --namespace="$namespace" --dimensions="InstanceId=$instance_id" --metric-name="$metric_name" --value="$value"

--- a/recipes/nfs-client.rb
+++ b/recipes/nfs-client.rb
@@ -2,6 +2,7 @@
 # Recipe:: nfs-client
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe 'mh-opsworks-recipes::create-metrics-dependencies'
 
 storage_info = node.fetch(
   :storage, {
@@ -23,56 +24,89 @@ shared_storage_root = get_shared_storage_root
 # primarily for efs, which exports a filesystem on the root path always.
 nfs_server_export_root = storage_info[:nfs_server_export_root] || storage_info[:export_root]
 storage_hostname = ''
-storage_available = false
 
 if storage_info[:type] == 'external'
-  storage_available = true
   storage_hostname = storage_info[:nfs_server_host]
 else
   layer_shortname = storage_info[:layer_shortname]
   (storage_hostname, storage_available) = node[:opsworks][:layers][layer_shortname.to_sym][:instances].first
 end
 
-if storage_available
-  directory '/etc/auto.master.d' do
-    action :create
-    owner 'root'
-    group 'root'
-    mode '755'
-  end
+directory '/etc/auto.master.d' do
+  action :create
+  owner 'root'
+  group 'root'
+  mode '755'
+end
 
-  file '/etc/auto.matterhorn' do
-    action :create
-    owner 'root'
-    group 'root'
-    mode '640'
-    content %Q|#{export_root} -fstype=nfs4 #{storage_hostname}:#{nfs_server_export_root}\n|
-  end
+file '/etc/auto.matterhorn' do
+  action :create
+  owner 'root'
+  group 'root'
+  mode '640'
+  content %Q|#{export_root} -fstype=nfs4 #{storage_hostname}:#{nfs_server_export_root}\n|
+end
 
-  file '/etc/auto.master.d/matterhorn.autofs' do
-    action :create
-    owner 'root'
-    group 'root'
-    mode '640'
-    content "/- /etc/auto.matterhorn -t 3600 -n 1"
-  end
+file '/etc/auto.master.d/matterhorn.autofs' do
+  action :create
+  owner 'root'
+  group 'root'
+  mode '640'
+  content "/- /etc/auto.matterhorn -t 3600 -n 1"
+end
 
-  # Only restart if we don't have an active mount
-  execute 'service autofs restart' do
-    command 'service autofs restart'
-    not_if %Q|grep ' #{export_root} ' /proc/mounts|
-  end
+# Only restart if we don't have an active mount
+execute 'service autofs restart' do
+  command 'service autofs restart'
+  not_if %Q|grep ' #{export_root} ' /proc/mounts|
+end
 
-  execute 'warm directory' do
-    command %Q|ls -flai #{export_root}/|
-    retries 10
-    retry_delay 5
-  end
+execute 'warm directory' do
+  command %Q|ls -flai #{export_root}/|
+  retries 10
+  retry_delay 5
+end
 
-  directory shared_storage_root do
-    owner 'matterhorn'
-    group 'matterhorn'
-    mode '755'
-    recursive true
+directory shared_storage_root do
+  owner 'matterhorn'
+  group 'matterhorn'
+  mode '755'
+  recursive true
+end
+
+heartbeat_root_dir = shared_storage_root + "/.storage_heartbeat"
+aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
+
+cookbook_file 'nfs_available.sh' do
+  path '/usr/local/bin/nfs_available.sh'
+  owner 'root'
+  group 'root'
+  mode '755'
+end
+
+directory heartbeat_root_dir do
+  owner 'custom_metrics'
+  group 'custom_metrics'
+  mode '700'
+  recursive true
+end
+
+cron_d 'nfs_available' do
+  user 'custom_metrics'
+  minute '*/2'
+  # Redirect stderr and stdout to logger. The command is silent on succesful runs
+  command %Q(/usr/local/bin/nfs_available.sh "#{aws_instance_id}" "#{heartbeat_root_dir}" 2>&1 | logger -t info)
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end
+
+ruby_block "add nfs availability check" do
+  block do
+    region = 'us-east-1'
+    # This is idempotent according to the aws docs
+    topic_arn = %x(aws sns create-topic --name "#{topic_name}" --region #{region} --output text).chomp
+
+    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_nfs_availability" --alarm-description "NFS is unavailable #{alarm_name_prefix}" --metric-name NFSAvailable --namespace AWS/OpsworksCustom --statistic Minimum --period 120 --threshold 1 --comparison-operator LessThanThreshold --dimensions Name=InstanceId,Value=#{aws_instance_id} --evaluation-periods 1 --alarm-actions "#{topic_arn}" --ok-actions "#{topic_arn}")
+    Chef::Log.info command
+    %x(#{command})
   end
 end


### PR DESCRIPTION
This sets up a bash script via cron that submits a metric. If it can 
successfully write a file to a subdirectory in the shared stored it reports 1,
if not 0.

This is then bound to the relevant alarm.