### PR TITLE
Fix the matterhorn init script to restart until actually successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 1.0.3 - 1/8/2016
+
+* Fix find's mtime invocation to ensure we're compressing and reaping files at
+  the correct times. *Requires that the MySQL backup installation chef recipe be
+  run on the admin node.*
+* Relax the `matterhorn_availability` alert to require errors over two 2 minute
+  periods instead of just one.
+* Modify the matterhorn init script to check that the daemon started properly,
+  working around the race condition related to bundle loading. See the relevant
+  commit for details.
+
 ## 1.0.2 - 1/6/2016
 
 * Only set the `org.opencastproject.server.maxload` property on worker nodes -

--- a/recipes/monitor-matterhorn-daemon.rb
+++ b/recipes/monitor-matterhorn-daemon.rb
@@ -28,7 +28,7 @@ ruby_block "add matterhorn monitoring" do
     # This is idempotent according to the aws docs
     topic_arn = %x(aws sns create-topic --name "#{topic_name}" --region #{region} --output text).chomp
 
-    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_matterhorn_availability" --alarm-description "Matterhorn is unavailable #{alarm_name_prefix}" --metric-name MatterhornAvailable --namespace AWS/OpsworksCustom --statistic Minimum --period 120 --threshold 1 --comparison-operator LessThanThreshold --dimensions Name=InstanceId,Value=#{aws_instance_id} --evaluation-periods 1 --alarm-actions "#{topic_arn}" --ok-actions "#{topic_arn}")
+    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{alarm_name_prefix}_matterhorn_availability" --alarm-description "Matterhorn is unavailable #{alarm_name_prefix}" --metric-name MatterhornAvailable --namespace AWS/OpsworksCustom --statistic Minimum --period 120 --threshold 1 --comparison-operator LessThanThreshold --dimensions Name=InstanceId,Value=#{aws_instance_id} --evaluation-periods 2 --alarm-actions "#{topic_arn}" --ok-actions "#{topic_arn}")
     Chef::Log.info command
     %x(#{command})
   end

--- a/templates/default/matterhorn-init-script.erb
+++ b/templates/default/matterhorn-init-script.erb
@@ -30,6 +30,13 @@ lockfile=/var/lock/subsys/matterhorn
 [ -d "/var/lock/subsys" ] || lockfile="/var/lock/LCK.${prog}"
 pidfile="/var/run/${prog}.pid"
 
+# Used in the "restart until the daemon is actually working" feature
+# now included in start()
+test_string="j_username"
+max_start_attempts=10
+attempts=0
+
+
 killdelay=7
 
 # Load configuration files
@@ -58,6 +65,20 @@ start() {
 	# If we failed to start matterhorn but a lock was created, we want to remove
 	# the file (flock does not remove the file automatically):
 	[ ! $retval -eq 0 ] && rm -f $lockfile
+
+  # Attempt to restart the daemon until it actually looks like it's
+  # started correctly
+  sleep 10
+  if [ "$attempts" -lt "$max_start_attempts" ]
+    then
+      if ! $(/usr/bin/curl -s -L http://localhost/ | grep -q "$test_string"); then
+        attempts=$[$attempts + 1]
+        restart
+      fi
+    else
+      retval=1
+      smsg="Daemon did not start after $max_start_attempts attempts"
+  fi
 
 	[ $retval -eq 0 ] && success "$smsg" || failed "$smsg"
 	return $retval


### PR DESCRIPTION
Background:

There's a race condition that causes the daemon to not restart correctly about
10 to 15% of the time. The easiest check is to see if the login appears after
a restart. This modifies the init process to look for
"j_username" in the source of the homepage, which means we're past the race
condition and the daemon is up.

If it can't succeed in 10 attempts, it aborts.