### PR TITLE
MATT-1847 hot fix Otherpubs config tag

### DIFF
--- a/templates/default/edu.harvard.dce.otherpubs.service.OtherpubsService.properties.erb
+++ b/templates/default/edu.harvard.dce.otherpubs.service.OtherpubsService.properties.erb
@@ -5,10 +5,10 @@
 # Used by Combo publication listing page
 
 edu.harvard.dce.otherpubs.dns=http://<%= @auth_host %>
-edu.harvard.dce.otherpubs.system.message.path=/includes/sys-msg.json
-edu.harvard.dce.otherpubs.offering.message.path=/$year/$term/$crn/$crn-msg.json
-edu.harvard.dce.otherpubs.live.url.template=/classroom/publicationListing.json
-edu.harvard.dce.otherpubs.offering.pub.url.template=/$year/$term/$crn/publicationListing.json
+edu.harvard.dce.otherpubs.system.message.path.template=/includes/sys-msg.json
+edu.harvard.dce.otherpubs.offering.message.path.template=/$year/$term/$crn/$crn-msg.json
+edu.harvard.dce.otherpubs.live.path.template=/classroom/publicationListing.json
+edu.harvard.dce.otherpubs.offering.pub.path.template=/$year/$term/$crn/publicationListing.json
 
 # For other (ac-web/Banner) course metadata data
 # Enable Access to Banner episode metadata via the Otherpubs endpoint


### PR DESCRIPTION
Hi Dan, can you review this hotfix for the current production deploy. The config tags changed for Otherpubs and this file puts the config in synch. 
