### PR TITLE
Usertracking session + uid log for reconciling anonymous shopper user actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## To be released
 
 * Clean up s3 distribution configuration. Remove asset server hooks.
+* *REQUIRES MANUAL CHEF RECIPE RUNS* engage nginx uid cookie & usertracking
+  session id + uid log for identifying shopping period viewers
 
 ## 1.0.6 - 1/18/2016
 

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -1,3 +1,9 @@
+userid on;
+userid_name dce_uid;
+userid_expires max;
+
+log_format session_uid '$cookie_JSESSIONID $uid_got';
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server ipv6only=on;
@@ -14,6 +20,7 @@ server {
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_buffering off;
 
   client_max_body_size 102400m;
   gzip on;
@@ -26,8 +33,13 @@ server {
     alias <%= @shared_storage_root %>/downloads;
   }
 
+  location /usertracking {
+    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>/usertracking;
+    access_log /var/log/nginx/session_uid.log session_uid;
+    access_log /var/log/nginx/access.log;
+  }
+
   location / {
-    proxy_buffering off;
     proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>;
   }
 }
@@ -58,6 +70,7 @@ server {
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_buffering off;
 
   # Ask matterhorn to redirect to HTTPS
   proxy_set_header X-Forwarded-SSL on;
@@ -75,8 +88,13 @@ server {
     alias <%= @shared_storage_root %>/downloads;
   }
 
+  location /usertracking {
+    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>/usertracking;
+    access_log /var/log/nginx/session_uid.log session_uid;
+    access_log /var/log/nginx/access.log;
+  }
+
   location / {
-    proxy_buffering off;
     proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>;
   }
 }


### PR DESCRIPTION
This updates the engage nginx config to set a unique "uid" cookie which on subsequent requests is logged to a new access log containing two values: the user's usertracking session id (JSESSIONID) and the tracking cookie. This log will later be used to associate "anonymous" user tracking events created during the shopping period with future events from those same users should they become registered.

Note: I debated about the uid cookie's expiration and decided to just go with "max" which means it basically never expires. We really only need it to persist past the point where it's possible for new students to register (i.e. a couple of weeks), but then I didn't want to rule out other, unanticipated ways it could be useful. Please express your strong feelings if you have them. 