### PR TITLE
Create an rsync-only "file_uploader" user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@
         # This is currently on the "Ganglia" layer in prod,
         # the value below is for dev clusters.
         ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin" recipes="mh-opsworks-recipes::install-mysql-backups"
+* *REQUIRES OPTIONAL CHEF RECIPE RUNS*  Installs the `file_uploader` user onto
+  the instance of your choice. This allows you to use an rsync backchannel for
+  uploads directly to the matterhorn inbox in combination with a couple cron jobs
+  to copy and maintain these uploads. If you want to use this feature, add it to
+  the setup lifecycle in the appropriate layer in your cluster config and then
+  run this recipe.  This recipe does not need to be run at any particular time
+  relative to a deployment.
+
+        # The current value for the admin node
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin" recipes="mh-opsworks-recipes::create-file-uploader-user"
 
 ## 1.1.0 - 1/28/2016
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 * Install the newrelic agent when '{"newrelic": {"key": "your key"}' is
   included in the stack's `custom_json`. See the main mh-opsworks README for
   info.
+* *REQUIRES MANUAL CHEF RECIPE RUNS* Make the mysql dumps more bandwidth
+  efficient by using "--compress" on the mysqldump client and an inline gzip
+  when saving to shared storage. This causes bandwidth during mysql dumps to
+  drop by 4 or 5 times without an appreciable performance penalty.  This recipe
+  can by run at any time, be sure to confirm the instance your dumps are
+  happening on by finding this recipe in your active cluster config.
+
+        # This is currently on the "Ganglia" layer in prod,
+        # the value below is for dev clusters.
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin" recipes="mh-opsworks-recipes::install-mysql-backups"
 
 ## 1.1.0 - 1/28/2016
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TO BE RELEASED
 
+* Install the newrelic agent when '{"newrelic": {"key": "your key"}' is
+  included in the stack's `custom_json`. See the main mh-opsworks README for
+  info.
+
 ## 1.1.0 - 1/28/2016
 
 * All clusters should now include a `private_assets_bucket_name` in their

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -438,7 +438,8 @@ module MhOpsworksRecipes
           main_config_file: %Q|#{matterhorn_repo_root}/current/etc/matterhorn.conf|,
           matterhorn_root: matterhorn_repo_root + '/current',
           felix_config_dir: matterhorn_repo_root + '/current/etc',
-          matterhorn_log_directory: log_dir
+          matterhorn_log_directory: log_dir,
+          enable_newrelic: enable_newrelic?
         })
       end
     end
@@ -482,6 +483,31 @@ module MhOpsworksRecipes
         variables({
           default_email_sender: default_email_sender,
         })
+      end
+    end
+
+    def enable_newrelic?
+      node[:newrelic]
+    end
+
+    def configure_newrelic(current_deploy_root, node_name)
+      if enable_newrelic?
+        log_dir = node.fetch(:matterhorn_log_directory, '/var/log/matterhorn')
+
+        newrelic_att = node.fetch(:newrelic, {})
+        newrelic_key = newrelic_att[:key]
+        environment_name = node[:opsworks][:stack][:name]
+        template %Q|#{current_deploy_root}/etc/newrelic.yml| do
+          source 'newrelic.yml.erb'
+          owner 'matterhorn'
+          group 'matterhorn'
+          variables({
+            newrelic_key: newrelic_key,
+            node_name: node_name,
+            environment_name: environment_name,
+            log_dir: log_dir
+          })
+        end
       end
     end
 

--- a/recipes/create-file-uploader-user.rb
+++ b/recipes/create-file-uploader-user.rb
@@ -1,0 +1,61 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-file_uploader-user
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+shared_storage_root = get_shared_storage_root
+storage_info = get_storage_info
+export_root = storage_info[:export_root]
+public_ssh_key = node.fetch(
+  :file_uploader_public_ssh_key,
+  %Q|ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDes9sir/DFtawDGx3dXJPAkOrU7RaCB0dmNp7rlzUIddWqBMsM/V8zcv1s0E3OL+hNc3egevGgb9IJEf0RE+efDkgX/EQJH5sXn9xZE8dyJTvgNp07rwgn/Btmt14fllVHUrwJF8DNtDduXiH3CsL72D7W4GYKs7CDpCT6WS/+qOvaaNFuxNH1cGKcKDNRZT9RBZZ/VnGZ58S+kB0uIXpfeH6XRi8jYdupSZRYHr75vc+NCGBPA1pis61fOBn8lSFZoYX5J7t8ZDYaWREAxy/GazP6sQIu43JI7KBUBQWp5PU3kNitPviTWiC4KCcsgFaAf6ifnunFB9HozHAm/4sN djcp@djcp-t5610|
+)
+
+rsync_upload_dir = "#{export_root}/rsync_uploads"
+
+directory rsync_upload_dir do
+  action :create
+  owner 'root'
+  group 'root'
+  mode '777'
+end
+
+group 'file_uploader' do
+  append true
+end
+
+user 'file_uploader' do
+  supports manage_home: true
+  comment 'Matterhorn application user'
+  gid 'file_uploader'
+  shell '/bin/bash'
+  home '/home/file_uploader'
+end
+
+directory "/home/file_uploader/.ssh" do
+  action :create
+  owner 'file_uploader'
+  group 'file_uploader'
+  mode '700'
+end
+
+file "/home/file_uploader/.ssh/authorized_keys" do
+  content %Q|command="/usr/bin/rsync --server -vvulogDtprze.iLsfx . #{rsync_upload_dir}",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding #{public_ssh_key}|
+  owner 'file_uploader'
+  group 'file_uploader'
+  mode '600'
+end
+
+cron_d "move_rsync_uploads_into_place" do
+  user "root"
+  minute "*"
+  command %Q(cd #{rsync_upload_dir} && /usr/bin/run-one find ./ -type f ! -name '.*' -print0 | xargs -0 -I {} sh -c 'chown matterhorn.matterhorn "{}"; mv "{}" #{shared_storage_root}/inbox/;')
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end
+
+cron_d "remove_stale_rsync_uploads" do
+  user "root"
+  minute "30"
+  command %Q(cd #{rsync_upload_dir} && /usr/bin/run-one find ./ -type f -name '.*' -mtime 1 -delete)
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -48,6 +48,8 @@ allow_matterhorn_user_to_restart_daemon_via_sudo
 
 deploy_action = get_deploy_action
 
+newrelic_app_name = alarm_name_prefix
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -88,7 +90,11 @@ deploy_revision matterhorn_repo_root do
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
     install_published_event_details_email(most_recent_deploy, public_engage_hostname)
+    configure_newrelic(most_recent_deploy, newrelic_app_name)
+
+    # ADMIN SPECIFIC
     initialize_database(most_recent_deploy)
+    # /ADMIN SPECIFIC
 
     template %Q|#{most_recent_deploy}/etc/config.properties| do
       source 'config.properties.erb'

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -57,6 +57,8 @@ allow_matterhorn_user_to_restart_daemon_via_sudo
 
 deploy_action = get_deploy_action
 
+newrelic_app_name = alarm_name_prefix
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -94,6 +96,7 @@ deploy_revision matterhorn_repo_root do
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_published_event_details_email(most_recent_deploy, public_engage_hostname)
+    configure_newrelic(most_recent_deploy, newrelic_app_name)
 
     # ENGAGE SPECIFIC
     set_service_registry_dispatch_interval(most_recent_deploy)

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -49,6 +49,8 @@ allow_matterhorn_user_to_restart_daemon_via_sudo
 
 deploy_action = get_deploy_action
 
+newrelic_app_name = alarm_name_prefix
+
 deploy_revision matterhorn_repo_root do
   repo repo_url
   revision git_data.fetch(:revision, 'master')
@@ -86,6 +88,7 @@ deploy_revision matterhorn_repo_root do
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_published_event_details_email(most_recent_deploy, public_engage_hostname)
+    configure_newrelic(most_recent_deploy, newrelic_app_name)
 
     # WORKER SPECIFIC
     #TODO - this should probably be checked into the repo

--- a/templates/default/matterhorn-harness.erb
+++ b/templates/default/matterhorn-harness.erb
@@ -3,6 +3,10 @@
 prog="matterhorn"
 config="<%= @main_config_file %>"
 pidfile="/var/run/${prog}.pid"
+<% if @enable_newrelic %>
+NEW_RELIC_JAR="<%= @matterhorn_root %>/lib/ext/newrelic/newrelic.jar"
+NEWRELIC_CONFIG="-Dnewrelic.config.file=<%= @felix_config_dir %>/newrelic.yml"
+<% end %>
 
 # Times to try sending a SIGTERM before sending a SIGKILL
 kill_attempts=20
@@ -135,7 +139,13 @@ else
 	DEBUG=""
 fi
 
-MATTERHORN_OPTS="$GOSH $DEBUG $FELIX $GRAPHICS $JAVA $LOGGING $JMX $DISABLE_PHONEHOME $ADD_OPTS"
+<% if @enable_newrelic %>
+NEWRELIC="-javaagent:${NEW_RELIC_JAR} $NEWRELIC_CONFIG"
+<% else %>
+NEWRELIC=""
+<% end %>
+
+MATTERHORN_OPTS="$NEWRELIC $GOSH $DEBUG $FELIX $GRAPHICS $JAVA $LOGGING $JMX $DISABLE_PHONEHOME $ADD_OPTS"
 
 # Execute Capture-Agent device configuration
 $IS_CA && $CA/device_config.sh

--- a/templates/default/matterhorn-init-script.erb
+++ b/templates/default/matterhorn-init-script.erb
@@ -68,7 +68,7 @@ start() {
 
   # Attempt to restart the daemon until it actually looks like it's
   # started correctly
-  sleep 10
+  sleep 20
   if [ "$attempts" -lt "$max_start_attempts" ]
     then
       if ! $(/usr/bin/curl -s -L http://localhost/ | grep -q "$test_string"); then

--- a/templates/default/newrelic.yml.erb
+++ b/templates/default/newrelic.yml.erb
@@ -1,0 +1,295 @@
+# This file configures the New Relic Agent.  New Relic monitors
+# Java applications with deep visibility and low overhead.  For more details and additional
+# configuration options visit https://docs.newrelic.com/docs/java/java-agent-configuration.
+#
+# This configuration file is custom generated for Harvard Division of Continuing Education_1
+#
+# This section is for settings common to all environments.
+# Do not add anything above this next line.
+common: &default_settings
+
+  # ============================== LICENSE KEY ===============================
+  # You must specify the license key associated with your New Relic
+  # account. For example, if your license key is 12345 use this:
+  # license_key: '12345'
+  # The key binds your Agent's data to your account in the New Relic service.
+  license_key: "<%= @newrelic_key %>"
+
+  # Agent Enabled
+  # Use this setting to disable the agent instead of removing it from the startup command.
+  # Default is true.
+  agent_enabled: true
+
+  # Set the name of your application as you'd like it show up in New Relic.
+  # If enable_auto_app_naming is false, the agent reports all data to this application.
+  # Otherwise, the agent reports only background tasks (transactions for non-web applications)
+  # to this application. To report data to more than one application 
+  # (useful for rollup reporting), separate the application names with ";".
+  # For example, to report data to "My Application" and "My Application 2" use this:
+  # app_name: My Application;My Application 2
+  # This setting is required. Up to 3 different application names can be specified.
+  # The first application name must be unique.
+  app_name: <%= @node_name %>; <%= @environment_name %>
+
+  # To enable high security, set this property to true. When in high
+  # security mode, the agent will use SSL and obfuscated SQL. Additionally,
+  # request parameters and message parameters will not be sent to New Relic.
+  high_security: false
+
+  # Set to true to enable support for auto app naming.
+  # The name of each web app is detected automatically
+  # and the agent reports data separately for each one.
+  # This provides a finer-grained performance breakdown for
+  # web apps in New Relic.
+  # Default is false.
+  enable_auto_app_naming: false
+
+  # Set to true to enable component-based transaction naming.
+  # Set to false to use the URI of a web request as the name of the transaction.
+  # Default is true.
+  enable_auto_transaction_naming: true
+
+  # The agent uses its own log file to keep its logging
+  # separate from that of your application.  Specify the log level here.
+  # This setting is dynamic, so changes do not require restarting your application.
+  # The levels in increasing order of verboseness are:
+  #   off, severe, warning, info, fine, finer, finest
+  # Default is info.
+  log_level: info
+
+  # Log all data sent to and from New Relic in plain text.
+  # This setting is dynamic, so changes do not require restarting your application.
+  # Default is false.
+  audit_mode: false
+
+  # The number of backup log files to save.
+  # Default is 1.
+  log_file_count: 5
+
+  # The maximum number of kbytes to write to any one log file.
+  # The log_file_count must be set greater than 1.
+  # Default is 0 (no limit).
+  log_limit_in_kbytes: 500
+
+  # Override other log rolling configuration and roll the logs daily.
+  # Default is false.
+  log_daily: false
+
+  # The name of the log file.
+  # Default is newrelic_agent.log.
+  log_file_name: newrelic_agent.log
+
+  # The log file directory.
+  # Default is the logs directory in the newrelic.jar parent directory.
+  log_file_path: <%= @log_dir %>
+
+  # The agent communicates with New Relic via https by
+  # default.  If you want to communicate with newrelic via http,
+  # then turn off SSL by setting this value to false.
+  # This work is done asynchronously to the threads that process your
+  # application code, so response times will not be directly affected
+  # by this change.
+  # Default is true.
+  ssl: true
+
+  # Proxy settings for connecting to the New Relic server:
+  # If a proxy is used, the host setting is required.  Other settings
+  # are optional.  Default port is 8080.  The username and password
+  # settings will be used to authenticate to Basic Auth challenges
+  # from a proxy server.
+  #proxy_host: hostname
+  #proxy_port: 8080
+  #proxy_user: username
+  #proxy_password: password
+
+  # Limits the number of lines to capture for each stack trace. 
+  # Default is 30
+  max_stack_trace_lines: 30
+
+  # Provides the ability to configure the attributes sent to New Relic. These
+  # attributes can be found in transaction traces, traced errors, Insight's 
+  # transaction events, and Insight's page views.
+  attributes:
+  
+    # When true, attributes will be sent to New Relic. The default is true.
+    enabled: true
+    
+    #A comma separated list of attribute keys whose values should 
+    # be sent to New Relic.
+    #include:
+    
+    # A comma separated list of attribute keys whose values should 
+    # not be sent to New Relic.
+    #exclude:
+    
+
+  # Transaction tracer captures deep information about slow
+  # transactions and sends this to the New Relic service once a
+  # minute. Included in the transaction is the exact call sequence of
+  # the transactions including any SQL statements issued.
+  transaction_tracer:
+
+    # Transaction tracer is enabled by default. Set this to false to turn it off.
+    # This feature is not available to Lite accounts and is automatically disabled.
+    # Default is true.
+    enabled: true
+
+    # Threshold in seconds for when to collect a transaction
+    # trace. When the response time of a controller action exceeds
+    # this threshold, a transaction trace will be recorded and sent to
+    # New Relic. Valid values are any float value, or (default) "apdex_f",
+    # which will use the threshold for the "Frustrated" Apdex level
+    # (greater than four times the apdex_t value).
+    # Default is apdex_f.
+    transaction_threshold: apdex_f
+
+    # When transaction tracer is on, SQL statements can optionally be
+    # recorded. The recorder has three modes, "off" which sends no
+    # SQL, "raw" which sends the SQL statement in its original form,
+    # and "obfuscated", which strips out numeric and string literals.
+    # Default is obfuscated.
+    record_sql: obfuscated
+
+    # Set this to true to log SQL statements instead of recording them.
+    # SQL is logged using the record_sql mode.
+    # Default is false.
+    log_sql: false
+
+    # Threshold in seconds for when to collect stack trace for a SQL
+    # call. In other words, when SQL statements exceed this threshold,
+    # then capture and send to New Relic the current stack trace. This is
+    # helpful for pinpointing where long SQL calls originate from.
+    # Default is 0.5 seconds.
+    stack_trace_threshold: 0.5
+
+    # Determines whether the agent will capture query plans for slow
+    # SQL queries. Only supported for MySQL and PostgreSQL.
+    # Default is true.
+    explain_enabled: true
+
+    # Threshold for query execution time below which query plans will not 
+    # not be captured.  Relevant only when `explain_enabled` is true.
+    # Default is 0.5 seconds.
+    explain_threshold: 0.5
+
+    # Use this setting to control the variety of transaction traces.
+    # The higher the setting, the greater the variety.
+    # Set this to 0 to always report the slowest transaction trace.
+    # Default is 20.
+    top_n: 20
+
+  # Error collector captures information about uncaught exceptions and
+  # sends them to New Relic for viewing.
+  error_collector:
+
+    # This property enables the collection of errors. If the property is not
+    # set or the property is set to false, then errors will not be collected.
+    # Default is true.
+    enabled: true
+
+    # Use this property to exclude specific exceptions from being reported as errors
+    # by providing a comma separated list of full class names.
+    # The default is to exclude akka.actor.ActorKilledException. If you want to override
+    # this, you must provide any new value as an empty list is ignored.
+    ignore_errors: akka.actor.ActorKilledException
+
+    # Use this property to exclude specific http status codes from being reported as errors
+    # by providing a comma separated list of status codes.
+    # The default is to exclude 404s. If you want to override
+    # this, you must provide any new value as an empty list is ignored.
+    ignore_status_codes: 404
+
+  # Transaction Events are used for Histograms and Percentiles. Unaggregated data is collected
+  # for each web transaction and sent to the server on harvest. 
+  transaction_events:
+
+    # Set to false to disable transaction events.
+    # Default is true.
+    enabled: true
+
+    # Events are collected up to the configured amount. Afterwards, events are sampled to
+    # maintain an even distribution across the harvest cycle.
+    # Default is 2000.  Setting to 0 will disable.
+    max_samples_stored: 2000
+
+  # Cross Application Tracing adds request and response headers to
+  # external calls using supported HTTP libraries to provide better
+  # performance data when calling applications monitored by other New Relic Agents.
+  cross_application_tracer:
+
+    # Set to false to disable cross application tracing.
+    # Default is true.
+    enabled: true
+
+  # Thread profiler measures wall clock time, CPU time, and method call counts
+  # in your application's threads as they run.
+  # This feature is not available to Lite accounts and is automatically disabled.
+  thread_profiler:
+
+    # Set to false to disable the thread profiler.
+    # Default is true.
+    enabled: true
+
+  # New Relic Real User Monitoring gives you insight into the performance real users are
+  # experiencing with your website. This is accomplished by measuring the time it takes for
+  # your users' browsers to download and render your web pages by injecting a small amount
+  # of JavaScript code into the header and footer of each page. 
+  browser_monitoring:
+
+    # By default the agent automatically inserts API calls in compiled JSPs to
+    # inject the monitoring JavaScript into web pages. Not all rendering engines are supported.
+    # See https://docs.newrelic.com/docs/java/real-user-monitoring-in-java#manual_instrumentation
+    # for instructions to add these manually to your pages.
+    # Set this attribute to false to turn off this behavior.
+    auto_instrument: true
+
+  class_transformer:
+    # This instrumentation reports the name of the user principal returned from 
+    # HttpServletRequest.getUserPrincipal() when servlets and filters are invoked.
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+
+  # Phoebe: For pricing
+  utilization:
+    detect_aws: true
+    detect_docker: true
+
+  # User-configurable custom labels for this agent.  Labels are name-value pairs.
+  # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.
+  # Names and values may not contain colons (:) or semicolons (;).
+#  labels:
+#    env: {{ de_env }}
+
+    # An example label
+    #label_name: label_value
+
+
+# Application Environments
+# ------------------------------------------
+# Environment specific settings are in this section.
+# You can use the environment to override the default settings.
+# For example, to change the app_name setting.
+# Use -Dnewrelic.environment=<environment> on the Java startup command line
+# to set the environment.
+# The default environment is production.
+
+# NOTE if your application has other named environments, you should
+# provide configuration settings for these environments here.
+
+development:
+  <<: *default_settings
+  app_name: matterhorn (Development)
+
+test:
+  <<: *default_settings
+  app_name: matterhorn (Test)
+
+production:
+  <<: *default_settings
+
+staging:
+  <<: *default_settings
+  app_name: matterhorn (Staging)


### PR DESCRIPTION
This allows you to get files directly into the matterhorn inbox via rsync.
This allows uploads to be scripted easily.

To use this feature:
* create an ssh keypair,
* add the public key to your cluster config's "custom_json" section,
* invoke rsync from your clients that're uploading files:

        rsync --progress -auz -e "ssh -i <path to the private ssh key for this
user>" ~/sample_video/file_to_upload.avi file_uploader@<your node's public
hostname>:/var/matterhorn/rsync_uploads/

Includes:

* Install the "file_uploader" user with an authorized_key defined by
 "file_uploader_public_ssh_key" in your `custom_json`
* Limit the file_uploader user to only be able to run rsync in the
 nfs-mounted "rsync_uploads" directory.
* Install a cron job to move files from the `rsync_uploads` directory into
 the default matterhorn inbox directory.
* Install an hourly cron job to remove rsync uploads older than 24 hours
 to catch stale uploads.