### PR TITLE
Allow java unit tests to be run conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TO BE RELEASED
 
+* Allow java unit tests to be run during a (re)deploy. They do not run by
+  default.  If you want to run them by default for all deploys set
+  `skip_java_unit_tests` to `false` in your cluster config's `custom_json`
+  config. You can run unit tests manually via the
+  `deployment:redeploy_app_with_unit_tests` rake task.
 * *REQUIRES MANUAL CHEF RECIPE RUNS*: Use maven3 instead of maven2, prepares us
   for matterhorn 1.6.x
     # Right before the deploy. . .

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -598,9 +598,14 @@ module MhOpsworksRecipes
         worker: 'worker-standalone,serviceregistry,workspace',
         engage: 'engage-standalone,dist,serviceregistry,workspace'
       }
+      skip_unit_tests = node.fetch(:skip_java_unit_tests, 'true')
+      retry_this_many = 3
+      if skip_unit_tests.to_s == 'false'
+        retry_this_many = 0
+      end
       execute 'maven build for matterhorn' do
-        command %Q|cd #{current_deploy_root} && MAVEN_OPTS='-Xms256m -Xmx960m -XX:PermSize=64m -XX:MaxPermSize=256m' mvn clean install -DdeployTo="#{current_deploy_root}" -Dmaven.test.skip=true -P#{build_profiles[node_profile.to_sym]}|
-        retries 3
+        command %Q|cd #{current_deploy_root} && MAVEN_OPTS='-Xms256m -Xmx960m -XX:PermSize=64m -XX:MaxPermSize=256m' mvn clean install -DdeployTo="#{current_deploy_root}" -Dmaven.test.skip=#{skip_unit_tests} -P#{build_profiles[node_profile.to_sym]}|
+        retries retry_this_many
         retry_delay 30
       end
     end


### PR DESCRIPTION
This allows you to run a deploy that includes running the java unit tests.
Send in the "skip_java_unit_tests" custom chef variable with a
"true" (the default) or "false".

"false" means "run the tests". "true" means "skip the tests".

Don't retry if we're running unit tests