### PR TITLE
Create an nfs disk-space specific metric on the admin node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@
 * *REQUIRES MANUAL CHEF RECIPE RUNS*: Use maven3 instead of maven2, prepares us
   for matterhorn 1.6.x
     # Right before the deploy. . .
-    ./bin/rake stack:commands:update_chef_recipes stack:commands:execute_recipes_on_layers layers="Admin, Workers, Engage" recipes="mh-opsworks-recipes::install-mh-base-packages"
+        ./bin/rake stack:commands:update_chef_recipes stack:commands:execute_recipes_on_layers layers="Admin, Workers, Engage" recipes="mh-opsworks-recipes::install-mh-base-packages"
+* *REQUIRES MANUAL CHEF RECIPE RUNS* Install a cloudwatch metric and alarm to
+  track nfs mount space available. Does not require anything to be done during
+  a deployment.
+
+        ./bin/rake stack:commands:execute_recipes_on_layers recipes="mh-opsworks-recipes::install-custom-metrics,mh-opsworks-recipes::create-alerts-from-opsworks-metrics"
 
 ## 1.1.2 - 2/10/2016
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TO BE RELEASED
 
+* Allow java unit tests to be run during a (re)deploy. They do not run by
+  default.  If you want to run them by default for all deploys set
+  `skip_java_unit_tests` to `false` in your cluster config's `custom_json`
+  config. You can run unit tests manually via the
+  `deployment:redeploy_app_with_unit_tests` rake task.
 * *REQUIRES MANUAL CHEF RECIPE RUNS*: Use maven3 instead of maven2, prepares us
   for matterhorn 1.6.x
     # Right before the deploy. . .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TO BE RELEASED
 
+* *REQUIRES MANUAL CHEF RECIPE RUNS*: Use maven3 instead of maven2, prepares us
+  for matterhorn 1.6.x
+    # Right before the deploy. . .
+    ./bin/rake stack:commands:update_chef_recipes stack:commands:execute_recipes_on_layers layers="Admin, Workers, Engage" recipes="mh-opsworks-recipes::install-mh-base-packages"
+
 ## 1.1.2 - 2/10/2016
 
 * Allow the "create-file-uploader-user" recipe to fail, to work around

--- a/files/default/disk_free_metric.sh
+++ b/files/default/disk_free_metric.sh
@@ -3,9 +3,10 @@
 . /usr/local/bin/custom_metrics_shared.sh
 
 instance_id="$1"
+filesystem_type="$2"
 metric_name=""
 
-local_file_systems=$(mount | grep -E 'type ext|type xfs' | cut -f3 -d' ')
+local_file_systems=$(mount | grep -E "$filesystem_type" | cut -f3 -d' ')
 
 for partition_mount in $local_file_systems; do
   if [ $partition_mount = '/' ]; then
@@ -14,6 +15,6 @@ for partition_mount in $local_file_systems; do
     metric_suffix=$(echo -n "$partition_mount" | tr -c "[[:alnum:]]" "_")
     metric_name="SpaceFreeOn$metric_suffix"
   fi
-  percent_free=$(expr 100 - $(df -hlP "$partition_mount" | tail -1 | awk '{ print $5 }' | tr -d '/%//'))
+  percent_free=$(expr 100 - $(df -hP "$partition_mount" | tail -1 | awk '{ print $5 }' | tr -d '/%//'))
   aws cloudwatch put-metric-data --region="$region" --namespace="$namespace" --dimensions="InstanceId=$instance_id" --metric-name="$metric_name" --value="$percent_free" --unit Percent
 done

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -108,6 +108,15 @@ module MhOpsworksRecipes
       stack_name.downcase.gsub(/[^a-z\d\-_]/,'_')
     end
 
+    def calculate_disk_partition_metric_name(partition)
+      if partition == '/'
+        'SpaceFreeOnRootPartition'
+      else
+        metric_suffix = partition.gsub(/[^a-z\d]/,'_')
+        "SpaceFreeOn#{metric_suffix}"
+      end
+    end
+
     def rds_name
       %Q|#{stack_shortname}-database|
     end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -598,9 +598,14 @@ module MhOpsworksRecipes
         worker: 'worker-standalone,serviceregistry,workspace',
         engage: 'engage-standalone,dist,serviceregistry,workspace'
       }
+      skip_unit_tests = node.fetch(:skip_java_unit_tests, 'true')
+      retry_this_many = 3
+      if skip_unit_tests.to_s == 'false'
+        retry_this_many = 0
+      end
       execute 'maven build for matterhorn' do
-        command %Q|cd #{current_deploy_root} && MAVEN_OPTS='-Xms256m -Xmx960m -XX:PermSize=64m -XX:MaxPermSize=256m' mvn clean install -DdeployTo="#{current_deploy_root}" -Dmaven.test.skip=true -P#{build_profiles[node_profile.to_sym]}|
-        retries 3
+        command %Q|cd #{current_deploy_root} && MAVEN_OPTS='-Xms256m -Xmx960m -XX:PermSize=64m -XX:MaxPermSize=256m' mvn clean install -DdeployTo="#{current_deploy_root}" -Dmaven.test.skip=#{skip_unit_tests} -P#{build_profiles[node_profile.to_sym]}|
+        retries retry_this_many
         retry_delay 30
       end
     end

--- a/recipes/install-custom-metrics.rb
+++ b/recipes/install-custom-metrics.rb
@@ -45,8 +45,18 @@ cron_d 'disk_metrics' do
   user 'custom_metrics'
   minute '*/2'
   # Redirect stderr and stdout to logger. The command is silent on succesful runs
-  command %Q(/usr/local/bin/disk_free_metric.sh "#{aws_instance_id}" 2>&1 | logger -t info)
+  command %Q(/usr/local/bin/disk_free_metric.sh "#{aws_instance_id}" "type ext|type xfs" 2>&1 | logger -t info)
   path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end
+
+if admin_node?
+  cron_d 'nfs_disk_metrics' do
+    user 'custom_metrics'
+    minute '*/2'
+    # Redirect stderr and stdout to logger. The command is silent on succesful runs
+    command %Q(/usr/local/bin/disk_free_metric.sh "#{aws_instance_id}" "type nfs" 2>&1 | logger -t info)
+    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
 end
 
 cron_d 'load_metrics' do

--- a/recipes/install-mh-base-packages.rb
+++ b/recipes/install-mh-base-packages.rb
@@ -4,12 +4,17 @@
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 include_recipe "mh-opsworks-recipes::update-package-repo"
 
+package "maven2" do
+  action :purge
+  ignore_failure true
+end
+
 %w|autofs5
 curl
 dkms
 gzip
 libglib2.0-dev
-maven2
+maven
 mediainfo
 mysql-client
 nodejs

--- a/test/integration/default/bats/install-mh-base-packages.bats
+++ b/test/integration/default/bats/install-mh-base-packages.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "base packages are installed" {
-  for package in maven2 openjdk-7-jdk openjdk-7-jre \
+  for package in maven openjdk-7-jdk openjdk-7-jre \
     gstreamer0.10-plugins-base gstreamer0.10-plugins-good gstreamer0.10-tools \
     gstreamer0.10-plugins-bad gstreamer0.10-plugins-ugly \
     libglib2.0-dev mysql-client gzip tesseract-ocr; do


### PR DESCRIPTION
Includes:

* modify the disk_free_metric to accept a "type" parameter to choose
 which filesystem types to monitor.
* Add the metric alarm for the nfs mounts off the admin node