### PR TITLE
Install awscli directly via pip. Includes:

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,3 +49,7 @@ suites:
   - name: populate-maven-cache
     run_list:
       - recipe[mh-opsworks-recipes::populate-maven-cache]
+
+  - name: install-awscli
+    run_list:
+      - recipe[mh-opsworks-recipes::install-awscli]

--- a/Berksfile
+++ b/Berksfile
@@ -2,8 +2,6 @@ source "https://supermarket.chef.io"
 
 cookbook 'nfs', '~> 2.1.0'
 cookbook 'apt', '~> 2.9.2'
-cookbook 'build-essential', '~> 2.2.4'
-cookbook 'awscli', '~> 1.1.2'
 cookbook 'cron', '~> 1.6.1'
 
 metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@
 * *REQUIRES MANUAL CHEF RECIPE RUNS* Install a cloudwatch metric and alarm to
   track nfs mount space available. Does not require anything to be done during
   a deployment.
-
         ./bin/rake stack:commands:execute_recipes_on_layers recipes="mh-opsworks-recipes::install-custom-metrics,mh-opsworks-recipes::create-alerts-from-opsworks-metrics"
+* Install awscli directly, without the awscli recipe. Simplifies dependencies
+  significantly. Does not require manual chef recipe runs, it'll run
+  automatically when needed by other recipes.
 
 ## 1.1.3 - 2/7/2016
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,4 @@ version          '0.1.0'
 
 depends 'nfs', '~> 2.1.0'
 depends 'apt', '~> 2.9.2'
-depends 'build-essential', '~> 2.2.4'
-depends 'awscli', '~> 1.1.2'
 depends 'cron', '~> 1.6.1'

--- a/recipes/create-alerts-from-opsworks-metrics.rb
+++ b/recipes/create-alerts-from-opsworks-metrics.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: create-alerts-from-opsworks-metrics
 
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 ::Chef::Resource::RubyBlock.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
 ruby_block "add alarms" do

--- a/recipes/create-metrics-dependencies.rb
+++ b/recipes/create-metrics-dependencies.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: create-metrics-dependencies
 
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 
 user "custom_metrics" do
   comment 'The custom metrics reporting user'

--- a/recipes/create-mysql-alarms.rb
+++ b/recipes/create-mysql-alarms.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: create-mysql-alarms
 
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 ::Chef::Resource::RubyBlock.send(:include, MhOpsworksRecipes::RecipeHelpers)
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 

--- a/recipes/enable-enhanced-networking.rb
+++ b/recipes/enable-enhanced-networking.rb
@@ -3,7 +3,7 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 install_package('dkms')
 bucket_name = node.fetch(:shared_asset_bucket_name, 'mh-opsworks-shared-assets')
 dkms_version = node.fetch(:ixgbevf_version, "2.16.1")

--- a/recipes/install-awscli.rb
+++ b/recipes/install-awscli.rb
@@ -1,0 +1,14 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-awscli
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe "mh-opsworks-recipes::update-package-repo"
+install_package('python-pip')
+awscli_version = node.fetch(:awscli_version, '1.10.5')
+
+execute 'install awscli' do
+  command %Q|pip install awscli==#{awscli_version}|
+  retries 5
+  retry_delay 10
+  timeout 300
+end

--- a/recipes/install-ffmpeg.rb
+++ b/recipes/install-ffmpeg.rb
@@ -2,7 +2,7 @@
 # Recipe:: install-ffmpeg
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 include_recipe "mh-opsworks-recipes::update-package-repo"
 
 # The list of libraries that've been built against the ffmpeg binary (and are

--- a/recipes/install-mysql-backups.rb
+++ b/recipes/install-mysql-backups.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: install-mysql-backups
 
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 ::Chef::Resource::RubyBlock.send(:include, MhOpsworksRecipes::RecipeHelpers)
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 

--- a/recipes/populate-maven-cache.rb
+++ b/recipes/populate-maven-cache.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: populate-maven-cache
 
-include_recipe "awscli::default"
+include_recipe "mh-opsworks-recipes::install-awscli"
 
 bucket_name = node.fetch(:shared_asset_bucket_name, 'mh-opsworks-shared-assets')
 

--- a/test/integration/install-awscli/bats/install-awscli.bats
+++ b/test/integration/install-awscli/bats/install-awscli.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "aws is installed" {
+  which aws;
+}
+
+@test "aws is the expected version" {
+  aws --version command 2>&1 >/dev/null | grep 1.10.5;
+}


### PR DESCRIPTION
* Use our homegrown awscli installer instead of the upstream chef recipe
* Tie to a specific awscli release
* Test the awscli install and specified release