### PR TITLE
Configure a squid proxy for the storage IP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## TO BE RELEASED
 
+* Create a squid3 proxy to be used by the zadara storage array to get to s3 for
+  object store backups.  See
+  [mh-opsworks](https://github.com/harvard-dce/mh-opsworks/blob/master/README.zadara.md)
+  for more information about how to use this recipe. This recipe is independent
+  of deployments.
+
 ## 1.1.5 - 2/25/2016
 
 * *REQUIRES MANUAL CHEF RECIPE RUNS:* Set the bash prompt to be in color and

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -173,6 +173,19 @@ module MhOpsworksRecipes
       )
     end
 
+    def get_storage_hostname
+      storage_info = get_storage_info
+
+      if storage_info[:type] == 'external'
+        storage_info[:nfs_server_host]
+      else
+        layer_shortname = storage_info[:layer_shortname]
+        (storage_hostname, storage_available) = node[:opsworks][:layers][layer_shortname.to_sym][:instances].first
+
+        storage_hostname
+      end
+    end
+
     def get_shared_storage_root
       storage_info = get_storage_info
       storage_info[:shared_storage_root] || storage_info[:export_root]

--- a/recipes/create-squid-proxy-for-storage-cluster.rb
+++ b/recipes/create-squid-proxy-for-storage-cluster.rb
@@ -1,0 +1,21 @@
+require 'resolv'
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-squid-proxy-for-storage-cluster
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe "mh-opsworks-recipes::update-package-repo"
+
+install_package('squid3')
+
+storage_hostname = get_storage_hostname
+
+template %Q|/etc/squid3/squid.conf| do
+  source 'squid.conf.erb'
+  owner 'root'
+  group 'root'
+  variables({
+    storage_ip_address: ::Resolv.getaddress(storage_hostname)
+  })
+end
+
+execute 'service squid3 restart'

--- a/recipes/nfs-client.rb
+++ b/recipes/nfs-client.rb
@@ -5,13 +5,7 @@
 ::Chef::Resource::RubyBlock.send(:include, MhOpsworksRecipes::RecipeHelpers)
 include_recipe 'mh-opsworks-recipes::create-metrics-dependencies'
 
-storage_info = node.fetch(
-  :storage, {
-    export_root: '/var/tmp',
-    network: '10.0.0.0/8',
-    layer_shortname: 'storage'
-  }
-)
+storage_info = get_storage_info
 
 # Ensure nfs client requirements are installed
 install_package('autofs5')
@@ -24,14 +18,8 @@ shared_storage_root = get_shared_storage_root
 # the path we use everywhere else, use that for the export root.  This is
 # primarily for efs, which exports a filesystem on the root path always.
 nfs_server_export_root = storage_info[:nfs_server_export_root] || storage_info[:export_root]
-storage_hostname = ''
 
-if storage_info[:type] == 'external'
-  storage_hostname = storage_info[:nfs_server_host]
-else
-  layer_shortname = storage_info[:layer_shortname]
-  (storage_hostname, storage_available) = node[:opsworks][:layers][layer_shortname.to_sym][:instances].first
-end
+storage_hostname = get_storage_hostname
 
 directory '/etc/auto.master.d' do
   action :create

--- a/recipes/nfs-export.rb
+++ b/recipes/nfs-export.rb
@@ -3,13 +3,7 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
-storage_info = node.fetch(
-  :storage, {
-    export_root: '/var/tmp',
-    network: '10.0.0.0/8',
-    layer_shortname: 'storage'
-  }
-)
+storage_info = get_storage_info
 
 shared_storage_root = get_shared_storage_root
 

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -1,0 +1,53 @@
+# MANAGED BY CHEF. Changes will be overwritten
+#
+# This template is the default ubuntu 14.04 template with the comments (SO MANY
+# COMMENTS) removed.
+
+acl SSL_ports port 443
+acl Safe_ports port 80          # http
+acl Safe_ports port 21          # ftp
+acl Safe_ports port 443         # https
+acl Safe_ports port 70          # gopher
+acl Safe_ports port 210         # wais
+acl Safe_ports port 1025-65535  # unregistered ports
+acl Safe_ports port 280         # http-mgmt
+acl Safe_ports port 488         # gss-http
+acl Safe_ports port 591         # filemaker
+acl Safe_ports port 777         # multiling http
+acl CONNECT method CONNECT
+
+# zadara ACLs as defined here: https://support.zadarastorage.com/entries/69891364-Setup-Backup-To-S3-B2S3-Through-a-Proxy-In-Your-AWS-VPC
+acl vpsa src <%= @storage_ip_address %>/32
+
+acl s3 dstdom_regex .*s3\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.eu-central-1\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.sa-east-1\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.ap-northeast-1\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.eu-west-1\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.us-west-1\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.us-west-2\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.ap-southeast-2\.amazonaws\.com
+acl s3 dstdom_regex .*s3\.ap-southeast-1\.amazonaws\.com
+
+http_access allow vpsa s3
+
+http_access deny !Safe_ports
+
+http_access deny CONNECT !SSL_ports
+
+http_access allow localhost manager
+http_access deny manager
+
+http_access allow localhost
+
+http_access deny all
+
+http_port 3128
+
+coredump_dir /var/spool/squid3
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+refresh_pattern .               0       20%     4320
+


### PR DESCRIPTION
This recipe should be run on an instance with a public IP address, and acts as
a squid proxy for zadara s3 snapshots. Details here:

https://support.zadarastorage.com/entries/69891364-Setup-Backup-To-S3-B2S3-Through-a-Proxy-In-Your-AWS-VPC

Includes:

* Extract get_storage_hostname from nfs-client
* Configure squid3 to allow access to the various s3 endpoints from the
 resolved VPSA or storage IP address.