### PR TITLE
Make it easier to deploy matterhorn into a subdirectory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## TO BE RELEASED
 
+* *REQUIRES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*: 
+  Before doing a deploy, you must edit the production cluster config
+  `custom_json` to set:
+
+        "matterhorn_repo_root": "/opt/matterhorn/deploy",
+        "nginx_log_root_dir": "/opt/matterhorn",
+
+  `matterhorn_repo_root` already exists and should be updated -
+  `nginx_log_root_dir` is new and should be created. Proceed to update chef
+  recipes and do your deploy normally after that.
+
+  This new feature clarifies the name of the deployed app and allows it to
+  easily be moved into a separate subdirectory under /opt/matterhorn.  The manual
+  recipe run below can be run at any time after a successful deploy.
+
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin, Workers, Engage" recipes="mh-opsworks-recipes::remove-legacy-deploy-dir"
+
 ## 1.1.5 - 2/25/2016
 
 * Create a squid3 proxy to be used by the zadara storage array to get to s3 for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## TO BE RELEASED
 
 * *REQUIRES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*: 
-  Before doing a deploy, you must edit the production cluster config
-  `custom_json` to set:
+  Before doing a deploy and after the morning scaled instances have started,
+  you must edit the production cluster config `custom_json` to set:
 
         "matterhorn_repo_root": "/opt/matterhorn/deploy",
         "nginx_log_root_dir": "/opt/matterhorn",
@@ -18,6 +18,13 @@
   recipe run below can be run at any time after a successful deploy.
 
         ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin, Workers, Engage" recipes="mh-opsworks-recipes::remove-legacy-deploy-dir"
+
+* *REQUIRES MANUAL CHEF RECIPE RUNS*: Open up nginx logs to be world-readable
+  by default. This happens post daily log rotation
+
+        # After the recipes have been updated. . .
+        ./bin/rake stack:commands:execute_recipes_on_layers recipes="mh-opsworks-recipes::configure-nginx-proxy" layers="Admin, Workers"
+        ./bin/rake stack:commands:execute_recipes_on_layers recipes="mh-opsworks-recipes::configure-engage-nginx-proxy" layers="Engage"
 
 ## 1.1.5 - 2/25/2016
 

--- a/files/default/nginx-logrotate.conf
+++ b/files/default/nginx-logrotate.conf
@@ -6,7 +6,7 @@
 # Compress immediately after rotating. we've got zcat, zgrep and zless, ppl! --DJCP
 #	delaycompress
 	notifempty
-	create 0640 www-data adm
+	create 0644 www-data adm
 	sharedscripts
 	prerotate
 		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -50,7 +50,8 @@ deploy_action = get_deploy_action
 
 newrelic_app_name = alarm_name_prefix
 
-deploy_revision matterhorn_repo_root do
+deploy_revision "matterhorn" do
+  deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
   enable_submodules true

--- a/recipes/deploy-database.rb
+++ b/recipes/deploy-database.rb
@@ -19,7 +19,8 @@ repo_url = git_repo_url(git_data)
 
 deploy_action = get_deploy_action
 
-deploy_revision matterhorn_repo_root do
+deploy_revision "matterhorn" do
+  deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
   enable_submodules true

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -59,7 +59,8 @@ deploy_action = get_deploy_action
 
 newrelic_app_name = alarm_name_prefix
 
-deploy_revision matterhorn_repo_root do
+deploy_revision "matterhorn" do
+  deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
   enable_submodules true

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -51,7 +51,8 @@ deploy_action = get_deploy_action
 
 newrelic_app_name = alarm_name_prefix
 
-deploy_revision matterhorn_repo_root do
+deploy_revision "matterhorn" do
+  deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
   enable_submodules true

--- a/recipes/install-deploy-key.rb
+++ b/recipes/install-deploy-key.rb
@@ -1,7 +1,6 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: install-deploy-key
 
-matterhorn_repo_root = node[:matterhorn_repo_root]
 git_data = node[:deploy][:matterhorn][:scm]
 
 ssh_key = git_data.fetch(:ssh_key, '')

--- a/recipes/remove-legacy-deploy-dir.rb
+++ b/recipes/remove-legacy-deploy-dir.rb
@@ -1,0 +1,19 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: remove-legacy-deploy-dir
+
+legacy_deploy_root = node.fetch(:legacy_deploy_root, '/opt/matterhorn')
+
+['/releases', '/shared'].each do |subdir|
+  directory %Q|#{legacy_deploy_root}#{subdir}| do
+    recursive true
+    action :delete
+    # Delete only if it's there and a directory
+    only_if %Q|[ -e "#{legacy_deploy_root}#{subdir}" ] && [ -d "#{legacy_deploy_root}#{subdir}" ]|
+  end
+end
+
+link %Q|#{legacy_deploy_root}/current| do
+  action :delete
+  # Delete only if it's a symlink
+  only_if %Q|[ -L "#{legacy_deploy_root}/current" ]|
+end


### PR DESCRIPTION
Create a recipe to allow you to remove a deployment root directory across all
nodes - this is dangerous and should not be run routinely.