### PR TITLE
Add an instances_started_ok metric and alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## TO BE RELEASED
 
+* *REQUIRES MANUAL CHEF RECIPE RUNS* Add a metric and alarm to check if
+  instances fail to start up. This can be done any time before or after a
+  deploy.
+
+        ./bin/rake stack:commands:execute_recipes_on_layers recipes="mh-opsworks-recipes::install-custom-metrics,mh-opsworks-recipes::create-alerts-from-opsworks-metrics"
+
 * *OPTIONAL EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:
   Recipes, etc for setting up Analytics layer/node. See README.analytics.md in
   mh-opsworks for setup instructions.

--- a/files/default/instances_started_ok_metric.sh
+++ b/files/default/instances_started_ok_metric.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. /usr/local/bin/custom_metrics_shared.sh
+
+stack_id="$1"
+metric_name="InstancesStartedOK"
+value=0
+
+output=$(aws opsworks describe-instances --region="$region" --stack-id="$stack_id" --output=text --query='Instances[?Status==`connection_lost`]||Instances[?Status==`setup_failed`]||Instances[?Status==`start_failed`]')
+
+if [ "$output" = '' ]; then
+  # No problems
+  value=1
+else
+  # Bad things happening
+  value=0
+fi
+
+aws cloudwatch put-metric-data --region="$region" --namespace="$namespace" --dimensions="StackId=$stack_id" --metric-name="$metric_name" --value="$value"

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -51,6 +51,10 @@ module MhOpsworksRecipes
       node['opsworks']['instance']['hostname'].match(/^admin/)
     end
 
+    def monitoring_node?
+      node['opsworks']['instance']['hostname'].match(/^monitoring\-master/)
+    end
+
     def get_db_seed_file
       node.fetch(:db_seed_file, 'dce-config/docs/scripts/ddl/mysql5.sql')
     end

--- a/recipes/install-custom-metrics.rb
+++ b/recipes/install-custom-metrics.rb
@@ -5,6 +5,7 @@
 include_recipe "mh-opsworks-recipes::create-metrics-dependencies"
 
 aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
+stack_id = node[:opsworks][:stack][:id]
 
 cookbook_file "disk_free_metric.sh" do
   path "/usr/local/bin/disk_free_metric.sh"
@@ -41,12 +42,29 @@ cookbook_file "memory_used_metric.sh" do
   mode "755"
 end
 
+cookbook_file "instances_started_ok_metric.sh" do
+  path "/usr/local/bin/instances_started_ok_metric.sh"
+  owner "root"
+  group "root"
+  mode "755"
+end
+
 cron_d 'disk_metrics' do
   user 'custom_metrics'
   minute '*/2'
   # Redirect stderr and stdout to logger. The command is silent on succesful runs
   command %Q(/usr/local/bin/disk_free_metric.sh "#{aws_instance_id}" "type ext|type xfs" 2>&1 | logger -t info)
   path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+end
+
+if monitoring_node?
+  cron_d 'instances_started_ok_metrics' do
+    user 'custom_metrics'
+    minute '*/2'
+    # Redirect stderr and stdout to logger. The command is silent on succesful runs
+    command %Q(/usr/local/bin/instances_started_ok_metric.sh "#{stack_id}" 2>&1 | logger -t info)
+    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
 end
 
 if admin_node?


### PR DESCRIPTION
It looks at all instances in the stack - if any are in
"connection_lost", "setup_failed", or "start_failed" (which are 
non-recoverable error states), report that as an error which will get thrown
to the SNS topic for this cluster.