### PR TITLE
MATT-2046 adding lti proxy props for mh_default_org.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## TO BE RELEASED
 
+* *REQUIRES EDITS TO EXISTING CLUSTER CONFIG*
+* MATT-2046 Enable the vanilla Opencast LTI endpoint, requires new lit_oauth custom_json
+* replace with the iCommons token from the private file (or create a new one from the iCommons APi webpage)
+* replace with the consumerkey and shared secret from the private file
+"stack": {
+    "chef": {
+    "custom_json": {
+      "icommons_api_token": "replace-with-an-icommons-api-token-or-manually-create-series-mappings",
+      "lti_oauth": {
+        "consumerkey": "dce_lti_oauth_consumer_key",
+        "sharedsecret": "dce_lti_oauth_sharedsecret"
+      },
+    ...
+
 ## v1.17.0 - 01/10/2017
 
 * update CA hack: 53chur-l01 now points to new prod akami stream id (same as byerly)

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -657,6 +657,19 @@ module MhOpsworksRecipes
       end
     end
 
+    def install_otherpubs_service_series_impl_config(current_deploy_root)
+
+      template %Q|#{current_deploy_root}/etc/services/edu.harvard.dce.otherseries.service.OtherSeriesServiceImpl.properties| do
+        icommons_api_token = node.fetch(:icommons_api_token, 'replace-with-an-icommons-api-token-or-manually-create-series-mappings')
+        source 'edu.harvard.dce.otherseries.service.OtherSeriesServiceImpl.properties.erb'
+        owner 'matterhorn'
+        group 'matterhorn'
+        variables({
+          icommons_api_token: icommons_api_token
+        })
+      end
+    end
+
     def set_service_registry_dispatch_interval(current_deploy_root)
       template %Q|#{current_deploy_root}/etc/services/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.properties| do
         source 'ServiceRegistryJpaImpl.properties.erb'
@@ -818,6 +831,29 @@ module MhOpsworksRecipes
           engage_hostname: engage_hostname
         })
       end
+    end
+
+    def install_default_tenant_config(current_deploy_root, public_dns_name, private_dns_name)
+      lti_oauth_info = get_lti_auth_info
+      template %Q|#{current_deploy_root}/etc/security/mh_default_org.xml| do
+        source 'mh_default_org.xml.erb'
+        owner 'matterhorn'
+        group 'matterhorn'
+        variables({
+          lti_oauth: lti_oauth_info,
+          unproxied_name: public_dns_name,
+          proxy_name: public_dns_name
+        })
+      end
+    end
+
+    def get_lti_auth_info
+      node.fetch(:lti_oauth,
+        {
+          consumer: 'consumerkey',
+          secret: 'sharedsecret'
+        }
+      )
     end
 
     def install_smtp_config(current_deploy_root)

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -95,12 +95,14 @@ deploy_revision "matterhorn" do
     install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
     remove_felix_fileinstall(most_recent_deploy)
     install_smtp_config(most_recent_deploy)
+    install_default_tenant_config(most_recent_deploy, public_admin_hostname, private_hostname)
     install_auth_service(
       most_recent_deploy, auth_host, auth_redirect_location, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     # Admin Specific
     install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
+    install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_aws_s3_file_archive_service_config(most_recent_deploy, region, s3_file_archive_bucket_name)
     install_ibm_watson_transcription_service_config(most_recent_deploy, ibm_watson_username, ibm_watson_psw)
     install_published_event_details_email(most_recent_deploy, public_engage_hostname)

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -102,11 +102,13 @@ deploy_revision "matterhorn" do
     install_multitenancy_config(most_recent_deploy, public_hostname, public_hostname)
     remove_felix_fileinstall(most_recent_deploy)
     install_smtp_config(most_recent_deploy)
+    install_default_tenant_config(most_recent_deploy, public_hostname, private_hostname)
     install_auth_service(
       most_recent_deploy, auth_host, auth_redirect_location, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
+    install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_aws_s3_file_archive_service_config(most_recent_deploy, region, s3_file_archive_bucket_name)
     install_ibm_watson_transcription_service_config(most_recent_deploy, ibm_watson_username, ibm_watson_psw) 
     install_published_event_details_email(most_recent_deploy, public_hostname)
@@ -116,7 +118,6 @@ deploy_revision "matterhorn" do
     initialize_database(most_recent_deploy)
 
     configure_usertracking(most_recent_deploy, user_tracking_authhost)
-    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
     install_aws_s3_distribution_service_config(most_recent_deploy, region, s3_distribution_bucket_name)
     install_matterhorn_images_properties(most_recent_deploy)
     # /all-in-one SPECIFIC

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -89,6 +89,7 @@ deploy_revision "matterhorn" do
     install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
     remove_felix_fileinstall(most_recent_deploy)
     install_smtp_config(most_recent_deploy)
+    install_default_tenant_config(most_recent_deploy, public_engage_hostname, private_hostname)
     install_auth_service(
       most_recent_deploy, auth_host, auth_redirect_location, auth_activated
     )
@@ -100,6 +101,7 @@ deploy_revision "matterhorn" do
     set_service_registry_dispatch_interval(most_recent_deploy)
     configure_usertracking(most_recent_deploy, user_tracking_authhost)
     install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
+    install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_aws_s3_distribution_service_config(most_recent_deploy, region, s3_distribution_bucket_name)
     # /ENGAGE SPECIFIC
 

--- a/templates/default/edu.harvard.dce.otherseries.service.OtherSeriesServiceImpl.properties.erb
+++ b/templates/default/edu.harvard.dce.otherseries.service.OtherSeriesServiceImpl.properties.erb
@@ -1,0 +1,11 @@
+# Configuration for DCE Other Series Service
+
+# For series dereferencing between Canvas (iCommons) and DCE Matterhorn
+# Used by the LTI publication listing tool
+
+# Comma separated list of other hosts for seriesId dereferencing
+otherpubs.series.hosts=Canvas
+
+# Config properties to retrieve series from other host (post fix with host name)
+otherpubs.series.url.Canvas=https://icommons-rest-api.tlt.harvard.edu/api/course/v2/course_instances/
+otherpubs.series.token.Canvas=<%= @icommons_api_token %>

--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -1,0 +1,288 @@
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:osgi="http://www.springframework.org/schema/osgi"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/osgi
+       http://www.springframework.org/schema/osgi/spring-osgi.xsd
+       http://www.springframework.org/schema/security
+       http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+
+  <!-- ######################################## -->
+  <!-- # Open and unsecured url patterns      # -->
+  <!-- ######################################## -->
+
+  <sec:http pattern="/admin/img/**" security="none" />
+  <sec:http pattern="/favicon.ico" security="none" />
+  <sec:http pattern="/images/**" security="none" />
+  <sec:http pattern="/img/**" security="none" />
+  <sec:http pattern="/js/**" security="none" />
+  <sec:http pattern="/style.css" security="none" />
+  <sec:http pattern="/css/**" security="none" />
+
+  <sec:http create-session="ifRequired" servlet-api-provision="true" realm="Opencast Matterhorn"
+    entry-point-ref="matterhornEntryPoint">
+
+    <!-- ################ -->
+    <!-- # URL SECURITY # -->
+    <!-- ################ -->
+
+    <!-- Allow anonymous access to the login form -->
+    <sec:intercept-url pattern="/login.html" access="ROLE_ANONYMOUS" />
+
+    <!-- Enable anonymous access to the /info/me.json resource -->
+    <sec:intercept-url pattern="/info/me.json" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/info/components.json" method="GET" access="ROLE_ANONYMOUS" />
+
+	<!-- #DCE Rute MATT-1260-remove-external-mh - test local uses this link now, which is a 
+	     redirect to Paella. This should come before /engage/ui/** because the order matters! -->
+    <sec:intercept-url pattern="/engage/ui/redirectToPaella.html" method="GET" access="ROLE_ADMIN" />
+    <!-- Enable anonymous access to the engage player and the GET endpoints it requires -->
+    <sec:intercept-url pattern="/engage/ui/**" access="ROLE_ANONYMOUS" />
+    <!-- #DCE KHD: DCE paella player is at this path -->
+    <sec:intercept-url pattern="/engage/player/**" method="GET" access="ROLE_ANONYMOUS" />
+    <!-- #DCE KHD: Alt paths: DCE former paella player, prep theodulpass -->
+    <sec:intercept-url pattern="/paella2.0/ui/**" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/theodulpass/ui/**" method="GET" access="ROLE_ANONYMOUS" />
+    <!-- #DCE KHD: MATT-1569 endpoint for Legacy pub data -->
+    <sec:intercept-url pattern="/otherpubs/**" method="GET" access="ROLE_ANONYMOUS" />    
+    <!-- Default Matterhorn engage player module loads at engage-player -->
+    <!--  #DCE -->
+    <sec:intercept-url pattern="/engage-player/**" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/search/**" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/usertracking/footprint*" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/usertracking/detailenabled" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/usertracking/stats*" method="GET" access="ROLE_ANONYMOUS" />
+    <!-- #DCE MATT-522 The following get is for paella.ajax.get /usertracking/?_method=PUT  -->
+    <sec:intercept-url pattern="/usertracking/" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/usertracking/**" method="GET" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/static/**" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/export/**" method="GET" access="ROLE_ANONYMOUS" />
+
+    <!-- Enable anonymous access to the series endpoints -->
+    <sec:intercept-url pattern="/series/**" method="GET" access="ROLE_ANONYMOUS" />
+
+    <!-- MATT-2094 Annotation endpoint: access depends on which endpoint is used -->
+    <!-- Reading annotations, security is done in REST endpoint -->
+    <sec:intercept-url pattern="/annotation/annotations*" method="GET" access="ROLE_ANONYMOUS" />
+    <!-- Can annotate?, role annonimous -->
+    <sec:intercept-url pattern="/annotation/canAnnotate*" method="GET" access="ROLE_ANONYMOUS" />
+    <!-- Read specific annotation, role  admin only -->
+    <sec:intercept-url pattern="/annotation/**" method="GET" access="ROLE_ADMIN" />
+    <!-- Adding annotation, security is done in REST endpoint -->
+    <sec:intercept-url pattern="/annotation/" method="PUT" access="ROLE_ANONYMOUS" />
+    <!-- Updating annotation, role admin only -->
+    <sec:intercept-url pattern="/annotation/**" method="PUT" access="ROLE_ADMIN" />
+    <!-- Deleting annotation, role admin only -->
+    <sec:intercept-url pattern="/annotation/**" method="DELETE" access="ROLE_ADMIN" />
+
+    <!-- Enable anonymous access to the OAI-PMH repository              -->
+    <!-- The OAI-PMH specification demands boths GET and POST requests  -->
+    <!-- Please make sure that the path configured here matches         -->
+    <!-- the path configured for the repository servlet.                -->
+    <sec:intercept-url pattern="/oaipmh/**" method="GET" access="ROLE_ANONYMOUS"/>
+    <sec:intercept-url pattern="/oaipmh/**" method="POST" access="ROLE_ANONYMOUS"/>
+
+    <!-- Enable anonymous access to the rss and atom feeds -->
+    <sec:intercept-url pattern="/feeds/**" method="GET" access="ROLE_ANONYMOUS" />
+
+    <!-- Secure the system management URLs for admins only -->
+    <sec:intercept-url pattern="/services/*" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/system/**" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/config/**" access="ROLE_ADMIN" />
+
+    <!-- Secure the user management URLs for admins only -->
+    <sec:intercept-url pattern="/users/**" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/admin/users.html" access="ROLE_ADMIN" />
+
+    <!-- Enable 2-legged OAuth access ("signed fetch") to the LTI launch servlet -->
+    <sec:intercept-url pattern="/lti" access="ROLE_ADMIN, ROLE_OAUTH_USER" />
+
+    <!-- Enable access to the LTI sample tool -->
+    <sec:intercept-url pattern="/ltisample/**" access="ROLE_ADMIN, ROLE_OAUTH_USER" />
+
+    <!-- Enable access to the LTI tools -->
+    <sec:intercept-url pattern="/ltitools/**" access="ROLE_ADMIN, ROLE_OAUTH_USER" />
+
+    <sec:intercept-url pattern="/transcripts/watson/results*" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/transcripts/watson/results*" method="POST" access="ROLE_ANONYMOUS" />
+
+    <!-- Everything else is for the admin users -->
+    <sec:intercept-url pattern="/**" access="ROLE_ADMIN, ROLE_COURSE_ADMIN, ROLE_INSTRUCTOR" />
+
+    <!-- ############################# -->
+    <!-- # LOGIN / LOGOUT MECHANISMS # -->
+    <!-- ############################# -->
+
+    <!-- Uncomment to enable x509 client certificates for identifying clients -->
+    <!-- sec:x509 subject-principal-regex="CN=(.*?)," user-service-ref="userDetailsService" / -->
+
+    <!-- Enable and configure the failure URL for form-based logins -->
+    <sec:form-login authentication-failure-url="/login.html?error" authentication-success-handler-ref="authSuccessHandler" />
+
+    <!-- Digest auth is used by capture agents and is used to enable transparent clustering of services -->
+    <sec:custom-filter position="BASIC_AUTH_FILTER" ref="digestFilter" />
+
+    <!-- Matterhorn is shipping its own implementation of the anonymous filter -->
+    <sec:custom-filter ref="anonymousFilter" position="ANONYMOUS_FILTER" />
+
+    <!--
+      2-legged oauth is used by trusted 3rd party applications, including LTI producers.
+      If you do not plan to use OAuth, comment this out. -->
+    <sec:custom-filter after="BASIC_AUTH_FILTER" ref="oauthProtectedResourceFilter" />
+
+    <!-- Enables "remember me" functionality -->
+    <sec:remember-me key="matterhorn" user-service-ref="userDetailsService" />
+
+    <!-- Set the request cache -->
+    <sec:request-cache ref="requestCache" />
+
+    <!-- If any URLs are to be exposed to anonymous users, the "sec:anonymous" filter must be present -->
+    <sec:anonymous enabled="false" />
+
+    <!-- Enables log out -->
+    <sec:logout />
+
+  </sec:http>
+
+  <!-- ######################################## -->
+  <!-- # Custom Anonymous Filter Definition   # -->
+  <!-- ######################################## -->
+
+  <bean id="anonymousFilter" class="org.opencastproject.kernel.security.TrustedAnonymousAuthenticationFilter">
+    <property name="userAttribute" ref="anonymousUserAttributes" />
+    <property name="key" value="anonymousKey" />
+  </bean>
+
+  <bean id="anonymousUserAttributes" class="org.springframework.security.core.userdetails.memory.UserAttribute">
+    <property name="authoritiesAsString" value="ROLE_ANONYMOUS"/>
+    <property name="password" value="empty"/>
+  </bean>
+
+  <!-- ######################################## -->
+  <!-- # Authentication Entry and Exit Points # -->
+  <!-- ######################################## -->
+
+  <!-- Differentiates between "normal" user requests and those requesting digest auth -->
+  <bean id="matterhornEntryPoint" class="org.opencastproject.kernel.security.DelegatingAuthenticationEntryPoint">
+    <property name="userEntryPoint" ref="userEntryPoint" />
+    <property name="digestAuthenticationEntryPoint" ref="digestEntryPoint" />
+  </bean>
+
+  <!-- Redirects unauthenticated requests to the login form -->
+  <bean id="userEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
+    <property name="loginFormUrl" value="/login.html" />
+  </bean>
+
+  <!-- Returns a 401 request for authentication via digest auth -->
+  <bean id="digestEntryPoint" class="org.springframework.security.web.authentication.www.DigestAuthenticationEntryPoint">
+    <property name="realmName" value="Opencast Matterhorn" />
+    <property name="key" value="matterhorn" />
+    <property name="nonceValiditySeconds" value="10" />
+  </bean>
+
+  <bean id="authSuccessHandler" class="org.opencastproject.kernel.security.AuthenticationSuccessHandler">
+    <property name="securityService" ref="securityService" />
+    <property name="welcomePages">
+      <map>
+        <entry key="ROLE_ADMIN" value="/welcome.html" />
+        <entry key="ROLE_COURSE_ADMIN" value="/welcome.html" />
+        <entry key="ROLE_INSTRUCTOR" value="/welcome.html" />
+        <entry key="ROLE_USER" value="/engage/ui/index.html" />
+        <entry key="*" value="/engage/ui/index.html" /> <!-- Any role not listed explicitly will redirect here -->
+      </map>
+    </property>
+  </bean>
+
+  <!-- ################# -->
+  <!-- # Digest Filter # -->
+  <!-- ################# -->
+
+  <!-- Handles the details of the digest authentication dance -->
+  <bean id="digestFilter" class="org.springframework.security.web.authentication.www.DigestAuthenticationFilter">
+    <!--  Use only the in-memory users, as these have passwords that are not hashed -->
+    <property name="userDetailsService" ref="userDetailsService" />
+    <property name="authenticationEntryPoint" ref="digestEntryPoint" />
+    <property name="createAuthenticatedToken" value="true" />
+    <property name="userCache">
+      <bean class="org.springframework.security.core.userdetails.cache.NullUserCache" />
+    </property>
+  </bean>
+
+  <!-- ####################### -->
+  <!-- # OAuth (LTI) Support # -->
+  <!-- ####################### -->
+
+  <!-- This is required for LTI. If you plan to use LTI, uncomment this and set
+       custom values for consumerkey and consumersecret: -->
+  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
+    <constructor-arg index="0" ref="userDetailsService" />
+    <constructor-arg index="1" value="<%= @lti_oauth[:consumerkey] %>" />
+    <constructor-arg index="2" value="<%= @lti_oauth[:sharedsecret] %>" />
+    <constructor-arg index="3" value="constructorName" />
+  </bean>
+
+  <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
+    <!-- start #DCE MATT-2046 proxy workaround params, comment these out if external and internal URLs match
+    The arg 0 is the String urlSentByLtiClient, the arg 1 is String urlUsedByProxyServer -->
+    <constructor-arg index="0" value = "https://<%= @proxy_name %>/lti" />
+    <constructor-arg index="1" value = "http://<%= @unproxied_name %>/lti" />
+    <!-- end MATT-2046 proxy workaround params -->
+    <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
+    <property name="tokenServices">
+      <bean class="org.springframework.security.oauth.provider.token.InMemoryProviderTokenServices" />
+    </property>
+    <property name="nonceServices">
+      <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
+    </property>
+    <property name="authHandler">
+      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
+        <constructor-arg index="0" ref="userDetailsService" />
+        <!-- Uncomment to allow the included keys to be trusted to provide known user details - - >
+        <constructor-arg index="1" ref="securityService" />
+        <constructor-arg index="2">
+          <list>
+            <value>trustedKey</value>
+            <value>trustedKey2</value>
+          </list>
+        </constructor-arg>
+        <! - - end of include keys to be a trusted provider-->
+      </bean>
+    </property>
+  </bean>
+  <!-- end of OAuth LTI edits -->
+
+  <!-- #################### -->
+  <!-- # OSGI Integration # -->
+  <!-- #################### -->
+
+  <!-- Obtain services from the OSGI service registry -->
+  <osgi:reference id="userDetailsService" cardinality="1..1"
+                  interface="org.springframework.security.core.userdetails.UserDetailsService" />
+
+  <osgi:reference id="securityService" cardinality="1..1"
+                  interface="org.opencastproject.security.api.SecurityService" />
+
+  <!-- Uncomment to enable external users e.g. used together shibboleth -->
+  <!-- <osgi:reference id="userReferenceProvider" cardinality="1..1"
+                  interface="org.opencastproject.userdirectory.JpaUserReferenceProvider"  /> -->
+
+
+  <!-- ############################# -->
+  <!-- # Spring Security Internals # -->
+  <!-- ############################# -->
+
+  <!-- The JPA user directory stores md5 hashed, salted passwords, so we must use a username-salted md5 password encoder. -->
+  <sec:authentication-manager alias="authenticationManager">
+    <sec:authentication-provider user-service-ref="userDetailsService">
+      <sec:password-encoder hash="md5"><sec:salt-source user-property="username" /></sec:password-encoder>
+    </sec:authentication-provider>
+  </sec:authentication-manager>
+
+  <!-- Do not use a request cache -->
+  <bean id="requestCache" class="org.springframework.security.web.savedrequest.NullRequestCache" />
+
+  <!-- Uncomment to enable logging interceptors -->
+  <!-- bean class="org.springframework.security.access.event.LoggerListener" / -->
+  <!-- bean class="org.springframework.security.authentication.event.LoggerListener" / -->
+
+</beans>


### PR DESCRIPTION
```
      deploy lti config to engage & admin node deploys (not workers, they get default)
      do not need the local dns change since nginx only forwards the protocol
```

This pull is dependent on hudcede/matterhorn-dce-fork/pull-requests/187/matt-2046-enable-default-vanilla-mh-163 in bitbucket because of the new 2 arg constructor for the LtiProcessingFilter. 
