### PR TITLE
matt-1875: provision recipes for flask-gunicorn apps

### DIFF
--- a/files/default/ca-webapp-logrotate.conf
+++ b/files/default/ca-webapp-logrotate.conf
@@ -1,0 +1,8 @@
+/home/web/logs/*.log {
+	daily
+	missingok
+	rotate 45
+	compress
+	notifempty
+	copytruncate
+}

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -382,6 +382,27 @@ module MhOpsworksRecipes
         mode '0600'
       end
     end
+
+    def get_ca_webapp_info
+      node.fetch(
+        :ca_webapp, {
+          ca_stats_user: 'user',
+          ca_stats_passwd: 'passwd',
+          ca_stats_json_url: 'http://ca-status.dceapp.net/ca_stats/ca_stats.json',
+          epipearl_user: 'admin',
+          epipearl_passwd: 'passwd',
+          ldap_host: 'dev-ldap1.dce.harvard.edu',
+          ldap_base_search: 'dc=dce,dc=harvard,dc=edu',
+          ldap_bind_dn: 'cn=user,dc=dce,dc=harvard,dc=edu',
+          ldap_bind_passwd: 'passwd',
+          cadash_secret_key: 'super_secret_really',
+          log_config: 'logging.yaml',
+          memcached_port: '8008',
+          webapp_git_repo: 'https://github.com/harvard-dce/webapp',
+          webapp_git_revision: 'master'
+          }
+        )
+    end
   end
 
   module DeployHelpers

--- a/recipes/configure-ca-webapp-gunicorn.rb
+++ b/recipes/configure-ca-webapp-gunicorn.rb
@@ -1,0 +1,29 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-ca-webapp-gunicorn
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+ca_webapp_info = node.fetch(:ca_webapp, {})
+app_name = ca_webapp_info.fetch(:ca_webapp_name, "webapp")
+
+execute "install gunicorn" do
+  command "source /home/web/sites/#{app_name}/venv/bin/activate && pip install gunicorn"
+  user "web"
+  creates "/home/web/sites/#{app_name}/venv/bin/gunicorn"
+end
+
+template "/home/web/sites/#{app_name}/gunicorn_start.sh" do
+  source "ca-webapp-gunicorn_start.sh.erb"
+  owner "web"
+  group "web"
+  mode "775"
+  variables({
+    ca_webapp_name: app_name
+  })
+end
+
+directory "/home/web/sock" do
+  owner "web"
+  group "web"
+  mode "775"
+end

--- a/recipes/configure-ca-webapp-nginx-proxy.rb
+++ b/recipes/configure-ca-webapp-nginx-proxy.rb
@@ -1,0 +1,27 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-ca-webapp-nginx-proxy
+
+include_recipe "mh-opsworks-recipes::update-package-repo"
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+ca_webapp_info = node.fetch(:ca_webapp, {})
+app_name = ca_webapp_info.fetch(:ca_webapp_name, "webapp")
+
+install_package("nginx")
+
+install_nginx_logrotate_customizations
+
+ssl_info = node.fetch(:ssl, get_dummy_cert)
+if cert_defined(ssl_info)
+  create_ssl_cert(ssl_info)
+  certificate_exists = true
+end
+
+template %Q|/etc/nginx/sites-enabled/default| do
+  source "ca-webapp-nginx-proxy-conf.erb"
+  manage_symlink_source true
+  variables({
+    ca_webapp: app_name
+  })
+end
+
+execute "service nginx reload"

--- a/recipes/configure-ca-webapp-supervisor.rb
+++ b/recipes/configure-ca-webapp-supervisor.rb
@@ -1,0 +1,18 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-ca-webapp-supervisor
+
+include_recipe "mh-opsworks-recipes::update-package-repo"
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+install_package("supervisor")
+
+ca_webapp_info = node.fetch(:ca_webapp, {})
+app_name = ca_webapp_info.fetch(:ca_webapp_name, "webapp")
+
+template %Q|/etc/supervisor/conf.d/#{app_name}.conf| do
+  source "ca-webapp-supervisor-conf.erb"
+  variables({
+    ca_webapp_name: app_name
+  })
+end
+
+execute %Q|service supervisor restart && supervisorctl start #{app_name}|

--- a/recipes/create-ca-webapp-directories.rb
+++ b/recipes/create-ca-webapp-directories.rb
@@ -1,0 +1,15 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-python-webapps-directories
+
+[
+  "/home/web/sites",
+  "/home/web/sock",
+  "/home/web/logs"
+].each do |webapps_directory|
+  directory webapps_directory do
+    owner "web"
+    group "web"
+    mode "755"
+    recursive true
+  end
+end

--- a/recipes/create-ca-webapp-user.rb
+++ b/recipes/create-ca-webapp-user.rb
@@ -1,0 +1,22 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-web-user
+
+group "web" do
+  append true
+  gid 2133
+end
+
+user "web" do
+  supports manage_home: true
+  comment "web application user"
+  uid 2133
+  gid "web"
+  shell "/bin/false"
+  home "/home/web"
+end
+
+directory "/home/web/.ssh" do
+  owner "web"
+  group "web"
+  mode "700"
+end

--- a/recipes/install-ca-webapp-packages.rb
+++ b/recipes/install-ca-webapp-packages.rb
@@ -1,0 +1,17 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-mh-base-packages
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe "mh-opsworks-recipes::update-package-repo"
+
+%w|python-dev
+python-virtualenv
+python-pip
+supervisor
+libpq-dev
+libffi-dev
+nginx|.each do |package_name|
+  install_package(package_name)
+end
+
+include_recipe "mh-opsworks-recipes::clean-up-package-cache"

--- a/recipes/install-ca-webapp.rb
+++ b/recipes/install-ca-webapp.rb
@@ -1,0 +1,54 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-ca-webapp
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+ca_webapp_info = node.fetch(:ca_webapp, {})
+app_name = ca_webapp_info.fetch(:ca_webapp_name, "webapp")
+
+git "git clone webapp #{app_name}" do
+  repository ca_webapp_info.fetch(:webapp_git_repo, "https://github.com/harvard-dce/webapp")
+  revision ca_webapp_info.fetch(:webapp_git_revision, "master")
+  destination "/home/web/sites/#{app_name}"
+  user 'web'
+end
+
+file "/home/web/sites/#{app_name}/#{app_name}.env" do
+  owner "web"
+  group "web"
+  content %Q|
+export CA_STATS_USER="#{ca_webapp_info[:ca_stats_user]}"
+export CA_STATS_PASSWD="#{ca_webapp_info[:ca_stats_passwd]}"
+export CA_STATS_JSON_URL="#{ca_webapp_info[:ca_stats_json_url]}"
+export EPIPEARL_USER="#{ca_webapp_info[:epipearl_user]}"
+export EPIPEARL_PASSWD="#{ca_webapp_info[:epipearl_passwd]}"
+export LDAP_HOST="#{ca_webapp_info[:ldap_host]}"
+export LDAP_BASE_SEARCH="#{ca_webapp_info[:ldap_base_search]}"
+export LDAP_BIND_DN="#{ca_webapp_info[:ldap_bind_dn]}"
+export LDAP_BIND_PASSWD="#{ca_webapp_info[:ldap_bind_passwd]}"
+export LOG_CONFIG="#{ca_webapp_info[:log_config]}"
+export FLASK_SECRET="#{ca_webapp_info[:webapp_secret_key]}"
+export DATABASE_USR="#{ca_webapp_info[:webapp_database_usr]}"
+export DATABASE_PWD="#{ca_webapp_info[:webapp_database_pwd]}"
+|
+  mode "600"
+end
+
+execute "create virtualenv" do
+  command "/usr/bin/virtualenv /home/web/sites/#{app_name}/venv"
+  user "web"
+  creates "/home/web/sites/#{app_name}/venv/bin/activate"
+end
+
+execute "install webapp dependencies" do
+  command "source /home/web/sites/#{app_name}/venv/bin/activate && pip install -r /home/web/sites/#{app_name}/requirements.txt"
+  user "web"
+end
+
+cookbook_file "ca-webapp-logrotate.conf" do
+  path "/etc/logrotate.d/#{app_name}"
+  owner "root"
+  group "root"
+  mode "644"
+end
+

--- a/recipes/install-redis-server.rb
+++ b/recipes/install-redis-server.rb
@@ -1,0 +1,6 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-redis-server
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+install_package('redis-server')
+

--- a/templates/default/ca-webapp-gunicorn_start.sh.erb
+++ b/templates/default/ca-webapp-gunicorn_start.sh.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+NAME="<%= @ca_webapp_name %>"
+FLASKDIR="/home/web/sites/${NAME}"
+VENVDIR="${FLASKDIR}/venv"
+SOCKFILE="/home/web/sock/${NAME}.sock"
+USER=web
+GROUP=web
+NUM_WORKERS=3
+
+echo "starting ${NAME}"
+
+# activate virtualenv
+source ${VENVDIR}/bin/activate
+
+export PYTHONPATH=${FLASKIDR}:${PYTHONPATH}
+
+# export all env vars for app
+source ${FLASKDIR}/${NAME}.env
+
+# create the run directory if it doesn't exist
+RUNDIR=$(dirname ${SOCKFILE})
+test -d ${RUNDIR} || mkdir -p ${RUNDIR}
+
+# start gunicorn
+exec gunicorn ${NAME}.app:create_app\(\) \
+    --name ${NAME} \
+    --workers ${NUM_WORKERS} \
+    --user=${USER} --group=${GROUP} \
+    --log-level=debug \
+    --log-file=- \
+    --bind=unix:${SOCKFILE}

--- a/templates/default/ca-webapp-nginx-proxy-conf.erb
+++ b/templates/default/ca-webapp-nginx-proxy-conf.erb
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name localhost;
+
+    return 301 https://$host$request_uri;
+}
+server {
+    listen 443 default_server ssl;
+
+    root /usr/share/nginx/html;
+
+    ssl_certificate     ssl/certificate.cert;
+    ssl_certificate_key ssl/certificate.key;
+
+    # some settings are recommended by
+    # https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+    # Need SSLv3 for IE on some older windows, this is the default set.
+    # ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+
+    server_name localhost;
+
+    # ask gunicorn to redirect to https
+    proxy_set_header X-Forwarded-SSL on;
+
+    #access_log /home/web/logs/nginx_access_log;
+    #error_log /home/web/logs/nginx_error_log;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    location / {
+        proxy_buffering off;
+        proxy_pass http://unix:/home/web/sock/<%= @ca_webapp %>.sock;
+    }
+
+    location /static {
+        alias /home/web/sites/<%= @ca_webapp %>/<%= @ca_webapp %>/static;
+        autoindex on;
+    }
+}
+

--- a/templates/default/ca-webapp-supervisor-conf.erb
+++ b/templates/default/ca-webapp-supervisor-conf.erb
@@ -1,0 +1,14 @@
+[program:<%= @ca_webapp_name %>]
+command = /home/web/sites/<%= @ca_webapp_name %>/gunicorn_start.sh
+directory = /home/web/sites/<%= @ca_webapp_name %>
+user = web
+redirect_stderr = True
+
+stdout_logfile = /home/web/logs/<%= @ca_webapp_name %>_gunicorn_stdout.log
+stderr_logfile = /home/web/logs/<%= @ca_webapp_name %>_gunicorn_stderr.log
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+stdout_logfile_backups = 0
+stderr_logfile_backups = 0
+
+


### PR DESCRIPTION
- create non-priviledged web user
- install python pkgs and supervisor
- virtualenv and pip requirements
- gunicorn start script virtualenv
- prevent re-create virtualenv
- redis
- logrotate for webapp related logs
- using refactor for certificates