### PR TITLE
matt-1875: provision recipes for flask-gunicorn apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## TO BE RELEASED
 
-* recipes to install and configure the utility node to host the capture-agent-manager
-  flask-gunicorn webapp
+* *[OPTIONAL]* Recipes to install and configure the utility node to host the
+  capture-agent-manager flask-gunicorn webapp. The utility node is optional and
+  only for DCE production cluster.
 
-* *REQUIRES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:
+* *[OPTIONAL] EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:
   recipes, etc to install and configure the utility node to host the capture-agent
-  manager flask-gunicorn webapp. see README.capture-agent-manager.md in
+  manager flask-gunicorn webapp. See README.capture-agent-manager.md in
   mh-opsworks for setup instructions.
+
   The manual recipe run can be executed any time since they affect only the
   utility node
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## TO BE RELEASED
 
+* recipes to install and configure the utility node to host the capture-agent-manager
+  flask-gunicorn webapp
+
+* *REQUIRES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:
+  recipes, etc to install and configure the utility node to host the capture-agent
+  manager flask-gunicorn webapp. see README.capture-agent-manager.md in
+  mh-opsworks for setup instructions.
+  The manual recipe run can be executed any time since they affect only the
+  utility node
+
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Utility"
+        recipes="mh-opsworks-recipes::create-capture-agent-manager-user,mh-opsworks-recipes::create-capture-agent-manager-directories,mh-opsworks-recipes:install-capture-agent-manager-packages,mh-opsworks-recipes:install-capture-agent-manager,mh-opsworks-recipes:configure-capture-agent-manager-gunicorn,mh-opsworks-recipes:configure-capture-agent-manager-nginx-proxy,mh-opsworks-recipes:configure-capture-agent-manager-supervisor"
+
+
 ## 1.3.3 - 5/19/2016
 
 * Fix all-in-one node provisioning, primarily for local vagrant development.

--- a/files/default/capture-agent-manager-logrotate.conf
+++ b/files/default/capture-agent-manager-logrotate.conf
@@ -1,0 +1,8 @@
+/home/capture_agent_manager/logs/*.log {
+	daily
+	missingok
+	rotate 7
+	compress
+	notifempty
+	copytruncate
+}

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -382,6 +382,27 @@ module MhOpsworksRecipes
         mode '0600'
       end
     end
+
+    def get_capture_agent_manager_info
+      node.fetch(
+        :capture_agent_manager, {
+          ca_stats_user: 'user',
+          ca_stats_passwd: 'passwd',
+          ca_stats_json_url: 'http://ca-status.dceapp.net/ca_stats/ca_stats.json',
+          epipearl_user: 'admin',
+          epipearl_passwd: 'passwd',
+          ldap_host: 'dev-ldap1.dce.harvard.edu',
+          ldap_base_search: 'dc=dce,dc=harvard,dc=edu',
+          ldap_bind_dn: 'cn=user,dc=dce,dc=harvard,dc=edu',
+          ldap_bind_passwd: 'passwd',
+          capture_agent_manager_secret_key: 'super_secret_really',
+          log_config: 'logging.yaml',
+          memcached_port: '8008',
+          capture_agent_manager_git_repo: 'https://github.com/harvard-dce/capture_agent_manager',
+          capture_agent_manager_git_revision: 'master'
+          }
+        )
+    end
   end
 
   module DeployHelpers

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -389,6 +389,7 @@ module MhOpsworksRecipes
           capture_agent_manager_app_name: 'cadash',
           capture_agent_manager_usr_name: 'capture_agent_manager',
           capture_agent_manager_secret_key: 'super_secret_key',
+          capture_agent_manager_gunicorn_log_level: 'debug',
           log_config: '/home/capture_agent_manager/sites/cadash/logging.yaml',
           ca_stats_user: 'usr',
           ca_stats_passwd: 'pwd',
@@ -399,7 +400,7 @@ module MhOpsworksRecipes
           ldap_base_search: 'dc=some-domain,dc=com',
           ldap_bind_dn: 'cn=fake_usr,dc=some-domain,dc=com',
           ldap_bind_passwd: 'pwd',
-          capture_agent_manager_git_repo: 'https://github.com/capture_agent_git_repo',
+          capture_agent_manager_git_repo: 'https://github.com/harvard-dce/cadash',
           capture_agent_manager_git_revision: 'master',
           capture_agent_manager_database_usr: 'usr',
           capture_agent_manager_database_pwd: 'pwd'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -382,6 +382,40 @@ module MhOpsworksRecipes
         mode '0600'
       end
     end
+
+    def get_capture_agent_manager_info
+      node.fetch(
+        :capture_agent_manager, {
+          capture_agent_manager_app_name: 'cadash',
+          capture_agent_manager_usr_name: 'capture_agent_manager',
+          capture_agent_manager_secret_key: 'super_secret_key',
+          log_config: '/home/capture_agent_manager/sites/cadash/logging.yaml',
+          ca_stats_user: 'usr',
+          ca_stats_passwd: 'pwd',
+          ca_stats_json_url: 'http://fake-ca-status.com/ca-status.json',
+          epipearl_user: 'usr',
+          epipearl_passwd: 'pwd',
+          ldap_host: 'ldap-hostname.some-domain.com',
+          ldap_base_search: 'dc=some-domain,dc=com',
+          ldap_bind_dn: 'cn=fake_usr,dc=some-domain,dc=com',
+          ldap_bind_passwd: 'pwd',
+          capture_agent_manager_git_repo: 'https://github.com/capture_agent_git_repo',
+          capture_agent_manager_git_revision: 'master',
+          capture_agent_manager_database_usr: 'usr',
+          capture_agent_manager_database_pwd: 'pwd'
+        }
+      )
+    end
+
+    def get_capture_agent_manager_app_name
+      ca_info = get_capture_agent_manager_info
+      ca_info[:capture_agent_manager_app_name]
+    end
+
+    def get_capture_agent_manager_usr_name
+      ca_info = get_capture_agent_manager_info
+      ca_info[:capture_agent_manager_usr_name]
+    end
   end
 
   module DeployHelpers

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -382,27 +382,6 @@ module MhOpsworksRecipes
         mode '0600'
       end
     end
-
-    def get_capture_agent_manager_info
-      node.fetch(
-        :capture_agent_manager, {
-          ca_stats_user: 'user',
-          ca_stats_passwd: 'passwd',
-          ca_stats_json_url: 'http://ca-status.dceapp.net/ca_stats/ca_stats.json',
-          epipearl_user: 'admin',
-          epipearl_passwd: 'passwd',
-          ldap_host: 'dev-ldap1.dce.harvard.edu',
-          ldap_base_search: 'dc=dce,dc=harvard,dc=edu',
-          ldap_bind_dn: 'cn=user,dc=dce,dc=harvard,dc=edu',
-          ldap_bind_passwd: 'passwd',
-          capture_agent_manager_secret_key: 'super_secret_really',
-          log_config: 'logging.yaml',
-          memcached_port: '8008',
-          capture_agent_manager_git_repo: 'https://github.com/harvard-dce/capture_agent_manager',
-          capture_agent_manager_git_revision: 'master'
-          }
-        )
-    end
   end
 
   module DeployHelpers

--- a/metadata.rb
+++ b/metadata.rb
@@ -867,6 +867,101 @@ and README.zadara.md in mh-opsworks.
 * squid3 is restarted to apply the new proxy config.
 '
 )
+recipe(
+  'mh-opsworks-recipes::configure-capture-agent-manager-gunicorn',
+  'sets up start script for gunicorn with capture-agent-manager app
+
+this is relevant for the utility node, where the capture-agent-manager `cadash`
+should run.
+
+=== attributes
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_app_name
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
+
+=== effects
+* gunicorn installed under the virtualenv for the capture-agent-manager-app root dir
+  (usually /home/user/sites/<app>/venv)
+* script to start gunicorn running the capture-agent-manager-app under app root dir
+'
+)
+recipe(
+  'mh-opsworks-recipes::configure-capture-agent-manager-nginx-proxy',
+  'sets up an nginx proxy that allows connections to flask-gunicorn apps via https-only
+
+=== attributes
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_app_name
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
+
+=== effects
+* A configured and restarted nginx linked to flask-gunicorn capture-agent-manager app
+* HTTPS-only setup
+'
+)
+recipe(
+  'mh-opsworks-recipes::configure-capture-agent-manager-supervisor',
+  'installs and sets up supervisor for gunicorn apps to run as service-daemon
+
+=== attributes
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_app_name
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
+
+=== effects
+* configured capture-agent-manager app as a supervisor task under `/etc/supervisord/conf.d/<app>.conf`
+* supervisor restarted
+'
+)
+recipe(
+  'mh-opsworks-recipes::create-capture-agent-manager-directories',
+  'creates directories(logs, app, etc) for capture-agent-manager flask-gunicorn app
+
+=== attributes
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
+
+=== effects
+* directories for app(sites), logs, sock created under capture-agent-manager user
+'
+)
+recipe(
+  'mh-opsworks-recipes::create-capture-agent-manager-user',
+  'create user and group to run capture-agent-manager flask-gunicorn app as
+
+=== attributes
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
+
+=== effects
+* capture-agent-manager user and group created
+* .ssh dir in home dir
+'
+)
+recipe(
+  'mh-opsworks-recipes::install-capture-agent-manager-packages',
+  '
+
+=== attributes
+none
+
+=== effects
+* packages needed for capture-agent-manager app to run like: redis, nginx, python,
+  and supervisor, among others
+* the package cache is cleared to save space
+'
+)
+recipe(
+  'mh-opsworks-recipes::install-capture-agent-manager',
+  'sets up flask-gunicorn app for capture-agent-manager
+
+=== attributes
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_info
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_app_name
+* MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
+
+=== effects
+* capture-agent-manager app cloned or checked out under capture-agent-manager `$HOME/sites`
+* environment vars for capture-agent-manager app are configured in a source file
+* pip dependencies installed in virtualenv under capture-agent-manager `$HOME/sites/venv`
+* configured logrotate file for capture-agent-manager app log
+'
+)
 
 depends 'nfs', '~> 2.1.0'
 depends 'apt', '~> 2.9.2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -869,9 +869,9 @@ and README.zadara.md in mh-opsworks.
 )
 recipe(
   'mh-opsworks-recipes::configure-capture-agent-manager-gunicorn',
-  'sets up start script for gunicorn with capture-agent-manager app
+  'Sets up start script for gunicorn with capture-agent-manager app
 
-this is relevant for the utility node, where the capture-agent-manager `cadash`
+This is relevant for the utility node, where the capture-agent-manager `cadash`
 should run.
 
 === attributes
@@ -886,7 +886,7 @@ should run.
 )
 recipe(
   'mh-opsworks-recipes::configure-capture-agent-manager-nginx-proxy',
-  'sets up an nginx proxy that allows connections to flask-gunicorn apps via https-only
+  'Sets up an nginx proxy that allows connections to flask-gunicorn apps via https-only
 
 === attributes
 * MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_app_name
@@ -899,7 +899,7 @@ recipe(
 )
 recipe(
   'mh-opsworks-recipes::configure-capture-agent-manager-supervisor',
-  'installs and sets up supervisor for gunicorn apps to run as service-daemon
+  'Installs and sets up supervisor for gunicorn apps to run as service-daemon
 
 === attributes
 * MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_app_name
@@ -912,7 +912,7 @@ recipe(
 )
 recipe(
   'mh-opsworks-recipes::create-capture-agent-manager-directories',
-  'creates directories(logs, app, etc) for capture-agent-manager flask-gunicorn app
+  'Creates directories(logs, app, etc) for capture-agent-manager flask-gunicorn app
 
 === attributes
 * MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
@@ -923,7 +923,7 @@ recipe(
 )
 recipe(
   'mh-opsworks-recipes::create-capture-agent-manager-user',
-  'create user and group to run capture-agent-manager flask-gunicorn app as
+  'Create user and group to run capture-agent-manager flask-gunicorn app as
 
 === attributes
 * MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_usr_name
@@ -935,7 +935,7 @@ recipe(
 )
 recipe(
   'mh-opsworks-recipes::install-capture-agent-manager-packages',
-  '
+  'Installs packages specific to the capture-agent-manager
 
 === attributes
 none
@@ -948,7 +948,7 @@ none
 )
 recipe(
   'mh-opsworks-recipes::install-capture-agent-manager',
-  'sets up flask-gunicorn app for capture-agent-manager
+  'Sets up flask-gunicorn app for capture-agent-manager
 
 === attributes
 * MhOpsworksRecipes::RecipeHelpers.get_capture_agent_manager_info

--- a/recipes/configure-capture-agent-manager-gunicorn.rb
+++ b/recipes/configure-capture-agent-manager-gunicorn.rb
@@ -3,22 +3,23 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
-capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
-app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+app_name = get_capture_agent_manager_app_name
+username = get_capture_agent_manager_usr_name
 
 execute "install gunicorn" do
-  command "source /home/capture_agent_manager/sites/#{app_name}/venv/bin/activate" \
+  command "source /home/#{username}/sites/#{app_name}/venv/bin/activate" \
     " && pip install gunicorn"
-  user "capture_agent_manager"
-  creates "/home/capture_agent_manager/sites/#{app_name}/venv/bin/gunicorn"
+  user username
+  creates "/home/#{username}/sites/#{app_name}/venv/bin/gunicorn"
 end
 
-template "/home/capture_agent_manager/sites/#{app_name}/gunicorn_start.sh" do
+template "/home/#{username}/sites/#{app_name}/gunicorn_start.sh" do
   source "capture-agent-manager-gunicorn-start.sh.erb"
-  owner "capture_agent_manager"
-  group "capture_agent_manager"
+  owner username
+  group username
   mode "775"
   variables({
-    capture_agent_manager_name: app_name
+    capture_agent_manager_name: app_name,
+    capture_agent_manager_username: username
   })
 end

--- a/recipes/configure-capture-agent-manager-gunicorn.rb
+++ b/recipes/configure-capture-agent-manager-gunicorn.rb
@@ -1,0 +1,30 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-capture-agent-manager-gunicorn
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
+app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+
+execute "install gunicorn" do
+  command "source /home/capture_agent_manager/sites/#{app_name}/venv/bin/activate" \
+    " && pip install gunicorn"
+  user "capture_agent_manager"
+  creates "/home/capture_agent_manager/sites/#{app_name}/venv/bin/gunicorn"
+end
+
+template "/home/capture_agent_manager/sites/#{app_name}/gunicorn_start.sh" do
+  source "capture-agent-manager-gunicorn-start.sh.erb"
+  owner "capture_agent_manager"
+  group "capture_agent_manager"
+  mode "775"
+  variables({
+    capture_agent_manager_name: app_name
+  })
+end
+
+directory "/home/capture_agent_manager/sock" do
+  owner "capture_agent_manager"
+  group "capture_agent_manager"
+  mode "775"
+end

--- a/recipes/configure-capture-agent-manager-gunicorn.rb
+++ b/recipes/configure-capture-agent-manager-gunicorn.rb
@@ -5,6 +5,8 @@
 
 app_name = get_capture_agent_manager_app_name
 usr_name = get_capture_agent_manager_usr_name
+capture_agent_manager_info = get_capture_agent_manager_info
+log_level = capture_agent_manager_info.fetch(:capture_agent_manager_gunicorn_log_level)
 
 execute "install gunicorn" do
   command "/home/#{usr_name}/sites/#{app_name}/venv/bin/pip install gunicorn"
@@ -19,6 +21,7 @@ template "/home/#{usr_name}/sites/#{app_name}/gunicorn_start.sh" do
   mode "775"
   variables({
     capture_agent_manager_name: app_name,
-    capture_agent_manager_usr_name: usr_name
+    capture_agent_manager_usr_name: usr_name,
+    capture_agent_manager_gunicorn_log_level: log_level
   })
 end

--- a/recipes/configure-capture-agent-manager-gunicorn.rb
+++ b/recipes/configure-capture-agent-manager-gunicorn.rb
@@ -4,22 +4,22 @@
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
 app_name = get_capture_agent_manager_app_name
-username = get_capture_agent_manager_usr_name
+usr_name = get_capture_agent_manager_usr_name
 
 execute "install gunicorn" do
-  command "source /home/#{username}/sites/#{app_name}/venv/bin/activate" \
+  command "source /home/#{usr_name}/sites/#{app_name}/venv/bin/activate" \
     " && pip install gunicorn"
-  user username
-  creates "/home/#{username}/sites/#{app_name}/venv/bin/gunicorn"
+  user usr_name
+  creates "/home/#{usr_name}/sites/#{app_name}/venv/bin/gunicorn"
 end
 
-template "/home/#{username}/sites/#{app_name}/gunicorn_start.sh" do
+template "/home/#{usr_name}/sites/#{app_name}/gunicorn_start.sh" do
   source "capture-agent-manager-gunicorn-start.sh.erb"
-  owner username
-  group username
+  owner usr_name
+  group usr_name
   mode "775"
   variables({
     capture_agent_manager_name: app_name,
-    capture_agent_manager_username: username
+    capture_agent_manager_usr_name: usr_name
   })
 end

--- a/recipes/configure-capture-agent-manager-gunicorn.rb
+++ b/recipes/configure-capture-agent-manager-gunicorn.rb
@@ -22,9 +22,3 @@ template "/home/capture_agent_manager/sites/#{app_name}/gunicorn_start.sh" do
     capture_agent_manager_name: app_name
   })
 end
-
-directory "/home/capture_agent_manager/sock" do
-  owner "capture_agent_manager"
-  group "capture_agent_manager"
-  mode "775"
-end

--- a/recipes/configure-capture-agent-manager-gunicorn.rb
+++ b/recipes/configure-capture-agent-manager-gunicorn.rb
@@ -7,8 +7,7 @@ app_name = get_capture_agent_manager_app_name
 usr_name = get_capture_agent_manager_usr_name
 
 execute "install gunicorn" do
-  command "source /home/#{usr_name}/sites/#{app_name}/venv/bin/activate" \
-    " && pip install gunicorn"
+  command "/home/#{usr_name}/sites/#{app_name}/venv/bin/pip install gunicorn"
   user usr_name
   creates "/home/#{usr_name}/sites/#{app_name}/venv/bin/gunicorn"
 end

--- a/recipes/configure-capture-agent-manager-nginx-proxy.rb
+++ b/recipes/configure-capture-agent-manager-nginx-proxy.rb
@@ -4,8 +4,8 @@
 include_recipe "mh-opsworks-recipes::update-package-repo"
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
-capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
-app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+app_name = get_capture_agent_manager_app_name
+username = get_capture_agent_manager_usr_name
 
 install_package("nginx")
 
@@ -17,20 +17,21 @@ if cert_defined(ssl_info)
   certificate_exists = true
 end
 
-directory '/etc/nginx/proxy-includes' do
-  owner 'root'
-  group 'root'
+directory "/etc/nginx/proxy-includes" do
+  owner "root"
+  group "root"
 end
 
-template %Q|/etc/nginx/sites-enabled/default| do
+template "/etc/nginx/sites-enabled/default" do
   source "nginx-proxy-ssl-only.erb"
   manage_symlink_source true
 end
 
-template %Q|/etc/nginx/proxy-includes/capture-agent-manager.conf| do
+template "/etc/nginx/proxy-includes/capture-agent-manager.conf" do
   source "nginx-proxy-capture-agent-manager.conf.erb"
   variables({
-    capture_agent_manager: app_name
+    capture_agent_manager: app_name,
+    capture_agent_manager_username: username
   })
 end
 

--- a/recipes/configure-capture-agent-manager-nginx-proxy.rb
+++ b/recipes/configure-capture-agent-manager-nginx-proxy.rb
@@ -1,0 +1,37 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-capture-agent-manager-nginx-proxy
+
+include_recipe "mh-opsworks-recipes::update-package-repo"
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
+app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+
+install_package("nginx")
+
+install_nginx_logrotate_customizations
+
+ssl_info = node.fetch(:ca_ssl, get_dummy_cert)
+if cert_defined(ssl_info)
+  create_ssl_cert(ssl_info)
+  certificate_exists = true
+end
+
+directory '/etc/nginx/proxy-includes' do
+  owner 'root'
+  group 'root'
+end
+
+template %Q|/etc/nginx/sites-enabled/default| do
+  source "nginx-proxy-ssl-only.erb"
+  manage_symlink_source true
+end
+
+template %Q|/etc/nginx/proxy-includes/capture-agent-manager.conf| do
+  source "nginx-proxy-capture-agent-manager.conf.erb"
+  variables({
+    capture_agent_manager: app_name
+  })
+end
+
+execute "service nginx reload"

--- a/recipes/configure-capture-agent-manager-nginx-proxy.rb
+++ b/recipes/configure-capture-agent-manager-nginx-proxy.rb
@@ -5,7 +5,7 @@ include_recipe "mh-opsworks-recipes::update-package-repo"
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
 app_name = get_capture_agent_manager_app_name
-username = get_capture_agent_manager_usr_name
+usr_name = get_capture_agent_manager_usr_name
 
 install_package("nginx")
 
@@ -31,7 +31,7 @@ template "/etc/nginx/proxy-includes/capture-agent-manager.conf" do
   source "nginx-proxy-capture-agent-manager.conf.erb"
   variables({
     capture_agent_manager: app_name,
-    capture_agent_manager_username: username
+    capture_agent_manager_usr_name: usr_name
   })
 end
 

--- a/recipes/configure-capture-agent-manager-supervisor.rb
+++ b/recipes/configure-capture-agent-manager-supervisor.rb
@@ -1,0 +1,18 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-capture-agent-manager-supervisor
+
+include_recipe "mh-opsworks-recipes::update-package-repo"
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+install_package("supervisor")
+
+capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
+app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+
+template %Q|/etc/supervisor/conf.d/#{app_name}.conf| do
+  source "capture-agent-manager-supervisor-conf.erb"
+  variables({
+    capture_agent_manager_name: app_name
+  })
+end
+
+execute %Q|service supervisor restart && supervisorctl start #{app_name}|

--- a/recipes/configure-capture-agent-manager-supervisor.rb
+++ b/recipes/configure-capture-agent-manager-supervisor.rb
@@ -6,13 +6,13 @@ include_recipe "mh-opsworks-recipes::update-package-repo"
 install_package("supervisor")
 
 app_name = get_capture_agent_manager_app_name
-username = get_capture_agent_manager_usr_name
+usr_name = get_capture_agent_manager_usr_name
 
 template "/etc/supervisor/conf.d/#{app_name}.conf" do
   source "capture-agent-manager-supervisor-conf.erb"
   variables({
     capture_agent_manager_name: app_name,
-    capture_agent_manager_username: username
+    capture_agent_manager_usr_name: usr_name
   })
 end
 

--- a/recipes/configure-capture-agent-manager-supervisor.rb
+++ b/recipes/configure-capture-agent-manager-supervisor.rb
@@ -5,14 +5,15 @@ include_recipe "mh-opsworks-recipes::update-package-repo"
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 install_package("supervisor")
 
-capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
-app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+app_name = get_capture_agent_manager_app_name
+username = get_capture_agent_manager_usr_name
 
-template %Q|/etc/supervisor/conf.d/#{app_name}.conf| do
+template "/etc/supervisor/conf.d/#{app_name}.conf" do
   source "capture-agent-manager-supervisor-conf.erb"
   variables({
-    capture_agent_manager_name: app_name
+    capture_agent_manager_name: app_name,
+    capture_agent_manager_username: username
   })
 end
 
-execute %Q|service supervisor restart|
+execute "service supervisor restart"

--- a/recipes/configure-capture-agent-manager-supervisor.rb
+++ b/recipes/configure-capture-agent-manager-supervisor.rb
@@ -15,4 +15,4 @@ template %Q|/etc/supervisor/conf.d/#{app_name}.conf| do
   })
 end
 
-execute %Q|service supervisor restart && supervisorctl start #{app_name}|
+execute %Q|service supervisor restart|

--- a/recipes/create-capture-agent-manager-directories.rb
+++ b/recipes/create-capture-agent-manager-directories.rb
@@ -1,0 +1,15 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-python-manager-directories
+
+[
+  "/home/capture_agent_manager/sites",
+  "/home/capture_agent_manager/sock",
+  "/home/capture_agent_manager/logs"
+].each do |capture_agent_manager_directory|
+  directory capture_agent_manager_directory do
+    owner "capture_agent_manager"
+    group "capture_agent_manager"
+    mode "755"
+    recursive true
+  end
+end

--- a/recipes/create-capture-agent-manager-directories.rb
+++ b/recipes/create-capture-agent-manager-directories.rb
@@ -1,14 +1,18 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: create-python-manager-directories
 
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+username = get_capture_agent_manager_usr_name
+
 [
-  "/home/capture_agent_manager/sites",
-  "/home/capture_agent_manager/sock",
-  "/home/capture_agent_manager/logs"
+  %Q|home/#{username}/sites|,
+  %Q|home/#{username}/sock|,
+  %Q|home/#{username}/logs|
 ].each do |capture_agent_manager_directory|
   directory capture_agent_manager_directory do
-    owner "capture_agent_manager"
-    group "capture_agent_manager"
+    owner username
+    group username
     mode "755"
     recursive true
   end

--- a/recipes/create-capture-agent-manager-directories.rb
+++ b/recipes/create-capture-agent-manager-directories.rb
@@ -3,16 +3,16 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
-username = get_capture_agent_manager_usr_name
+usr_name = get_capture_agent_manager_usr_name
 
 [
-  %Q|home/#{username}/sites|,
-  %Q|home/#{username}/sock|,
-  %Q|home/#{username}/logs|
+  %Q|home/#{usr_name}/sites|,
+  %Q|home/#{usr_name}/sock|,
+  %Q|home/#{usr_name}/logs|
 ].each do |capture_agent_manager_directory|
   directory capture_agent_manager_directory do
-    owner username
-    group username
+    owner usr_name
+    group usr_name
     mode "755"
     recursive true
   end

--- a/recipes/create-capture-agent-manager-user.rb
+++ b/recipes/create-capture-agent-manager-user.rb
@@ -1,0 +1,22 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: create-capture-agent-manager-user
+
+group "capture_agent_manager" do
+  append true
+  gid 2133
+end
+
+user "capture_agent_manager" do
+  supports manage_home: true
+  comment "capture agent manager user"
+  uid 2133
+  gid "capture_agent_manager"
+  shell "/bin/false"
+  home "/home/capture_agent_manager"
+end
+
+directory "/home/capture_agent_manager/.ssh" do
+  owner "capture_agent_manager"
+  group "capture_agent_manager"
+  mode "700"
+end

--- a/recipes/create-capture-agent-manager-user.rb
+++ b/recipes/create-capture-agent-manager-user.rb
@@ -3,24 +3,24 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
-username = get_capture_agent_manager_usr_name
+usr_name = get_capture_agent_manager_usr_name
 
-group username do
+group usr_name do
   append true
   gid 2133
 end
 
-user username do
+user usr_name do
   supports manage_home: true
   comment "capture agent manager user"
   uid 2133
   gid 2133
   shell "/bin/false"
-  home "/home/#{username}"
+  home "/home/#{usr_name}"
 end
 
-directory "/home/#{username}/.ssh" do
-  owner username
-  group username
+directory "/home/#{usr_name}/.ssh" do
+  owner usr_name
+  group usr_name
   mode "700"
 end

--- a/recipes/create-capture-agent-manager-user.rb
+++ b/recipes/create-capture-agent-manager-user.rb
@@ -1,22 +1,26 @@
 # Cookbook Name:: mh-opsworks-recipes
 # Recipe:: create-capture-agent-manager-user
 
-group "capture_agent_manager" do
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+username = get_capture_agent_manager_usr_name
+
+group username do
   append true
   gid 2133
 end
 
-user "capture_agent_manager" do
+user username do
   supports manage_home: true
   comment "capture agent manager user"
   uid 2133
-  gid "capture_agent_manager"
+  gid 2133
   shell "/bin/false"
-  home "/home/capture_agent_manager"
+  home "/home/#{username}"
 end
 
-directory "/home/capture_agent_manager/.ssh" do
-  owner "capture_agent_manager"
-  group "capture_agent_manager"
+directory "/home/#{username}/.ssh" do
+  owner username
+  group username
   mode "700"
 end

--- a/recipes/install-capture-agent-manager-packages.rb
+++ b/recipes/install-capture-agent-manager-packages.rb
@@ -1,0 +1,10 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-mh-base-packages
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe "mh-opsworks-recipes::update-package-repo"
+
+install_package("python-dev python-virtualenv python-pip " \
+                "supervisor libpq-dev libffi-dev nginx redis-server")
+
+include_recipe "mh-opsworks-recipes::clean-up-package-cache"

--- a/recipes/install-capture-agent-manager.rb
+++ b/recipes/install-capture-agent-manager.rb
@@ -42,7 +42,7 @@ execute "create virtualenv" do
 end
 
 execute "install capture_agent_manager dependencies" do
-  command %Q|source /home/#{usr_name}/sites/#{app_name}/venv/bin/activate && pip install -r /home/#{usr_name}/sites/#{app_name}/requirements.txt|
+  command %Q|/home/#{usr_name}/sites/#{app_name}/venv/bin/pip install -r /home/#{usr_name}/sites/#{app_name}/requirements.txt|
   user usr_name
 end
 

--- a/recipes/install-capture-agent-manager.rb
+++ b/recipes/install-capture-agent-manager.rb
@@ -1,0 +1,54 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-capture-agent-manager
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+capture_agent_manager_info = node.fetch(:capture_agent_manager, {})
+app_name = capture_agent_manager_info.fetch(:capture_agent_manager_name, "capture_agent_manager")
+
+git "git clone capture_agent_manager #{app_name}" do
+  repository capture_agent_manager_info.fetch(:capture_agent_manager_git_repo, "https://github.com/harvard-dce/capture_agent_manager")
+  revision capture_agent_manager_info.fetch(:capture_agent_manager_git_revision, "master")
+  destination "/home/capture_agent_manager/sites/#{app_name}"
+  user 'capture_agent_manager'
+end
+
+file "/home/capture_agent_manager/sites/#{app_name}/#{app_name}.env" do
+  owner "capture_agent_manager"
+  group "capture_agent_manager"
+  content %Q|
+export CA_STATS_USER="#{capture_agent_manager_info[:ca_stats_user]}"
+export CA_STATS_PASSWD="#{capture_agent_manager_info[:ca_stats_passwd]}"
+export CA_STATS_JSON_URL="#{capture_agent_manager_info[:ca_stats_json_url]}"
+export EPIPEARL_USER="#{capture_agent_manager_info[:epipearl_user]}"
+export EPIPEARL_PASSWD="#{capture_agent_manager_info[:epipearl_passwd]}"
+export LDAP_HOST="#{capture_agent_manager_info[:ldap_host]}"
+export LDAP_BASE_SEARCH="#{capture_agent_manager_info[:ldap_base_search]}"
+export LDAP_BIND_DN="#{capture_agent_manager_info[:ldap_bind_dn]}"
+export LDAP_BIND_PASSWD="#{capture_agent_manager_info[:ldap_bind_passwd]}"
+export LOG_CONFIG="#{capture_agent_manager_info[:log_config]}"
+export FLASK_SECRET="#{capture_agent_manager_info[:capture_agent_manager_secret_key]}"
+export DATABASE_USR="#{capture_agent_manager_info[:capture_agent_manager]}"
+export DATABASE_PWD="#{capture_agent_manager_info[:capture_agent_manager_database_pwd]}"
+|
+  mode "600"
+end
+
+execute "create virtualenv" do
+  command "/usr/bin/virtualenv /home/capture_agent_manager/sites/#{app_name}/venv"
+  user "capture_agent_manager"
+  creates "/home/capture_agent_manager/sites/#{app_name}/venv/bin/activate"
+end
+
+execute "install capture_agent_manager dependencies" do
+  command "source /home/capture_agent_manager/sites/#{app_name}/venv/bin/activate && pip install -r /home/capture_agent_manager/sites/#{app_name}/requirements.txt"
+  user "capture_agent_manager"
+end
+
+cookbook_file "capture-agent-manager-logrotate.conf" do
+  path "/etc/logrotate.d/#{app_name}"
+  owner "root"
+  group "root"
+  mode "644"
+end
+

--- a/recipes/install-capture-agent-manager.rb
+++ b/recipes/install-capture-agent-manager.rb
@@ -5,18 +5,18 @@
 
 capture_agent_manager_info = get_capture_agent_manager_info
 app_name = get_capture_agent_manager_app_name
-username = get_capture_agent_manager_usr_name
+usr_name = get_capture_agent_manager_usr_name
 
 git "git clone capture_agent_manager #{app_name}" do
   repository capture_agent_manager_info.fetch(:capture_agent_manager_git_repo)
   revision capture_agent_manager_info.fetch(:capture_agent_manager_git_revision)
-  destination %Q|/home/#{username}/sites/#{app_name}|
-  user username
+  destination %Q|/home/#{usr_name}/sites/#{app_name}|
+  user usr_name
 end
 
-file %Q|/home/#{username}/sites/#{app_name}/#{app_name}.env| do
-  owner username
-  group username
+file %Q|/home/#{usr_name}/sites/#{app_name}/#{app_name}.env| do
+  owner usr_name
+  group usr_name
   content %Q|
 export CA_STATS_USER="#{capture_agent_manager_info[:ca_stats_user]}"
 export CA_STATS_PASSWD="#{capture_agent_manager_info[:ca_stats_passwd]}"
@@ -36,14 +36,14 @@ export DATABASE_PWD="#{capture_agent_manager_info[:capture_agent_manager_databas
 end
 
 execute "create virtualenv" do
-  command %Q|/usr/bin/virtualenv /home/#{username}/sites/#{app_name}/venv|
-  user username
-  creates %Q|/home/#{username}/sites/#{app_name}/venv/bin/activate|
+  command %Q|/usr/bin/virtualenv /home/#{usr_name}/sites/#{app_name}/venv|
+  user usr_name
+  creates %Q|/home/#{usr_name}/sites/#{app_name}/venv/bin/activate|
 end
 
 execute "install capture_agent_manager dependencies" do
-  command %Q|source /home/#{username}/sites/#{app_name}/venv/bin/activate && pip install -r /home/#{username}/sites/#{app_name}/requirements.txt|
-  user username
+  command %Q|source /home/#{usr_name}/sites/#{app_name}/venv/bin/activate && pip install -r /home/#{usr_name}/sites/#{app_name}/requirements.txt|
+  user usr_name
 end
 
 cookbook_file "capture-agent-manager-logrotate.conf" do

--- a/templates/default/capture-agent-manager-gunicorn-start.sh.erb
+++ b/templates/default/capture-agent-manager-gunicorn-start.sh.erb
@@ -27,6 +27,6 @@ exec gunicorn ${NAME}.app:create_app\(\) \
     --name ${NAME} \
     --workers ${NUM_WORKERS} \
     --user=${USER} --group=${GROUP} \
-    --log-level=debug \
+    --log-level=<%= @capture_agent_manager_gunicorn_log_level %> \
     --log-file=- \
     --bind=unix:${SOCKFILE}

--- a/templates/default/capture-agent-manager-gunicorn-start.sh.erb
+++ b/templates/default/capture-agent-manager-gunicorn-start.sh.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+NAME="<%= @capture_agent_manager_name %>"
+FLASKDIR="/home/capture_agent_manager/sites/${NAME}"
+VENVDIR="${FLASKDIR}/venv"
+SOCKFILE="/home/capture_agent_manager/sock/${NAME}.sock"
+USER=capture_agent_manager
+GROUP=capture_agent_manager
+NUM_WORKERS=3
+
+echo "starting ${NAME}"
+
+# activate virtualenv
+source ${VENVDIR}/bin/activate
+
+export PYTHONPATH=${FLASKIDR}:${PYTHONPATH}
+
+# export all env vars for app
+source ${FLASKDIR}/${NAME}.env
+
+# create the run directory if it doesn't exist
+RUNDIR=$(dirname ${SOCKFILE})
+test -d ${RUNDIR} || mkdir -p ${RUNDIR}
+
+# start gunicorn
+exec gunicorn ${NAME}.app:create_app\(\) \
+    --name ${NAME} \
+    --workers ${NUM_WORKERS} \
+    --user=${USER} --group=${GROUP} \
+    --log-level=debug \
+    --log-file=- \
+    --bind=unix:${SOCKFILE}

--- a/templates/default/capture-agent-manager-gunicorn-start.sh.erb
+++ b/templates/default/capture-agent-manager-gunicorn-start.sh.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 NAME="<%= @capture_agent_manager_name %>"
-USER="<%= @capture_agent_manager_username %>"
+USER="<%= @capture_agent_manager_usr_name %>"
 GROUP=${USER}
 FLASKDIR="/home/${USER}/sites/${NAME}"
 VENVDIR="${FLASKDIR}/venv"

--- a/templates/default/capture-agent-manager-gunicorn-start.sh.erb
+++ b/templates/default/capture-agent-manager-gunicorn-start.sh.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 NAME="<%= @capture_agent_manager_name %>"
-USER="capture_agent_manager"
+USER="<%= @capture_agent_manager_username %>"
 GROUP=${USER}
 FLASKDIR="/home/${USER}/sites/${NAME}"
 VENVDIR="${FLASKDIR}/venv"

--- a/templates/default/capture-agent-manager-gunicorn-start.sh.erb
+++ b/templates/default/capture-agent-manager-gunicorn-start.sh.erb
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 NAME="<%= @capture_agent_manager_name %>"
-FLASKDIR="/home/capture_agent_manager/sites/${NAME}"
+USER="capture_agent_manager"
+GROUP=${USER}
+FLASKDIR="/home/${USER}/sites/${NAME}"
 VENVDIR="${FLASKDIR}/venv"
-SOCKFILE="/home/capture_agent_manager/sock/${NAME}.sock"
-USER=capture_agent_manager
-GROUP=capture_agent_manager
+SOCKFILE="/home/${USER}/sock/${NAME}.sock"
 NUM_WORKERS=3
 
 echo "starting ${NAME}"

--- a/templates/default/capture-agent-manager-supervisor-conf.erb
+++ b/templates/default/capture-agent-manager-supervisor-conf.erb
@@ -1,0 +1,14 @@
+[program:<%= @capture_agent_manager_name %>]
+command = /home/capture_agent_manager/sites/<%= @capture_agent_manager_name %>/gunicorn_start.sh
+directory = /home/capture_agent_manager/sites/<%= @capture_agent_manager_name %>
+user = capture_agent_manager
+redirect_stderr = True
+
+stdout_logfile = /home/capture_agent_manager/logs/<%= @capture_agent_manager_name %>_gunicorn_stdout.log
+stderr_logfile = /home/capture_agent_manager/logs/<%= @capture_agent_manager_name %>_gunicorn_stderr.log
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+stdout_logfile_backups = 0
+stderr_logfile_backups = 0
+
+

--- a/templates/default/capture-agent-manager-supervisor-conf.erb
+++ b/templates/default/capture-agent-manager-supervisor-conf.erb
@@ -1,11 +1,11 @@
 [program:<%= @capture_agent_manager_name %>]
-command = /home/capture_agent_manager/sites/<%= @capture_agent_manager_name %>/gunicorn_start.sh
-directory = /home/capture_agent_manager/sites/<%= @capture_agent_manager_name %>
-user = capture_agent_manager
+command = /home/<%= @capture_agent_manager_username %>/sites/<%= @capture_agent_manager_name %>/gunicorn_start.sh
+directory = /home/<%= @capture_agent_manager_username %>/sites/<%= @capture_agent_manager_name %>
+user = <%= @capture_agent_manager_username %>
 redirect_stderr = True
 
-stdout_logfile = /home/capture_agent_manager/logs/<%= @capture_agent_manager_name %>_gunicorn_stdout.log
-stderr_logfile = /home/capture_agent_manager/logs/<%= @capture_agent_manager_name %>_gunicorn_stderr.log
+stdout_logfile = /home/<%= @capture_agent_manager_username %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stdout.log
+stderr_logfile = /home/<%= @capture_agent_manager_username %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stderr.log
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 stdout_logfile_backups = 0

--- a/templates/default/capture-agent-manager-supervisor-conf.erb
+++ b/templates/default/capture-agent-manager-supervisor-conf.erb
@@ -1,11 +1,11 @@
 [program:<%= @capture_agent_manager_name %>]
-command = /home/<%= @capture_agent_manager_username %>/sites/<%= @capture_agent_manager_name %>/gunicorn_start.sh
-directory = /home/<%= @capture_agent_manager_username %>/sites/<%= @capture_agent_manager_name %>
-user = <%= @capture_agent_manager_username %>
+command = /home/<%= @capture_agent_manager_usr_name %>/sites/<%= @capture_agent_manager_name %>/gunicorn_start.sh
+directory = /home/<%= @capture_agent_manager_usr_name %>/sites/<%= @capture_agent_manager_name %>
+user = <%= @capture_agent_manager_usr_name %>
 redirect_stderr = True
 
-stdout_logfile = /home/<%= @capture_agent_manager_username %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stdout.log
-stderr_logfile = /home/<%= @capture_agent_manager_username %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stderr.log
+stdout_logfile = /home/<%= @capture_agent_manager_usr_name %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stdout.log
+stderr_logfile = /home/<%= @capture_agent_manager_usr_name %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stderr.log
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 stdout_logfile_backups = 0

--- a/templates/default/capture-agent-manager-supervisor-conf.erb
+++ b/templates/default/capture-agent-manager-supervisor-conf.erb
@@ -5,10 +5,7 @@ user = <%= @capture_agent_manager_usr_name %>
 redirect_stderr = True
 
 stdout_logfile = /home/<%= @capture_agent_manager_usr_name %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stdout.log
-stderr_logfile = /home/<%= @capture_agent_manager_usr_name %>/logs/<%= @capture_agent_manager_name %>_gunicorn_stderr.log
 stdout_logfile_maxbytes = 0
-stderr_logfile_maxbytes = 0
 stdout_logfile_backups = 0
-stderr_logfile_backups = 0
 
 

--- a/templates/default/nginx-proxy-capture-agent-manager.conf.erb
+++ b/templates/default/nginx-proxy-capture-agent-manager.conf.erb
@@ -1,0 +1,10 @@
+    location / {
+        proxy_buffering off;
+        proxy_pass http://unix:/home/capture_agent_manager/sock/<%= @capture_agent_manager %>.sock;
+    }
+
+    location /static {
+        alias /home/capture_agent_manager/sites/<%= @capture_agent_manager %>/<%= @capture_agent_manager %>/static;
+        autoindex on;
+    }
+

--- a/templates/default/nginx-proxy-capture-agent-manager.conf.erb
+++ b/templates/default/nginx-proxy-capture-agent-manager.conf.erb
@@ -1,10 +1,10 @@
     location / {
         proxy_buffering off;
-        proxy_pass http://unix:/home/<%= @capture_agent_manager_username %>/sock/<%= @capture_agent_manager %>.sock;
+        proxy_pass http://unix:/home/<%= @capture_agent_manager_usr_name %>/sock/<%= @capture_agent_manager %>.sock;
     }
 
     location /static {
-    alias /home/<%= @capture_agent_manager_username %>/sites/<%= @capture_agent_manager %>/<%= @capture_agent_manager %>/static;
+    alias /home/<%= @capture_agent_manager_usr_name %>/sites/<%= @capture_agent_manager %>/<%= @capture_agent_manager %>/static;
         autoindex on;
     }
 

--- a/templates/default/nginx-proxy-capture-agent-manager.conf.erb
+++ b/templates/default/nginx-proxy-capture-agent-manager.conf.erb
@@ -1,10 +1,10 @@
     location / {
         proxy_buffering off;
-        proxy_pass http://unix:/home/capture_agent_manager/sock/<%= @capture_agent_manager %>.sock;
+        proxy_pass http://unix:/home/<%= @capture_agent_manager_username %>/sock/<%= @capture_agent_manager %>.sock;
     }
 
     location /static {
-        alias /home/capture_agent_manager/sites/<%= @capture_agent_manager %>/<%= @capture_agent_manager %>/static;
+    alias /home/<%= @capture_agent_manager_username %>/sites/<%= @capture_agent_manager %>/<%= @capture_agent_manager %>/static;
         autoindex on;
     }
 

--- a/templates/default/nginx-proxy-ssl-only.erb
+++ b/templates/default/nginx-proxy-ssl-only.erb
@@ -1,0 +1,33 @@
+server {
+    listen 443 default_server ssl;
+    listen [::]:443 ipv6only=on ssl;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    ssl_certificate     ssl/certificate.cert;
+    ssl_certificate_key ssl/certificate.key;
+
+    # some settings are recommended by
+    # https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+    # Need SSLv3 for IE on some older windows, this is the default set.
+    # ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+
+    server_name localhost;
+
+    proxy_buffering off;
+    proxy_read_timeout 30m;
+    proxy_send_timeout 30m;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-SSL on;
+
+    client_max_body_size 102400m;
+    gzip on;
+
+    include /etc/nginx/proxy-includes/*.conf;
+
+}


### PR DESCRIPTION
- create non-priviledged user
- install python pkgs and supervisor
- virtualenv and pip requirements
- gunicorn start script virtualenv
- prevent re-create virtualenv
- redis
- logrotate for app related logs
- using refactor for certificates
- (fix pull #81) more descriptive names
- (fix pull #81) string of packages to `install-packages` recipe
- (fix pull #81) redis default save to disk is enough for now
- (fix pull #81) nginx configs
- (fix pull #81) logrotate keeps 7 logs instead of 45