### PR TITLE
bucket for storing last action timestamp needs to be unique per cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TO BE RELEASED
 
+* *[OPTIONAL]* Changes to the `install-ua-harvester` recipe. Changed naming path 
+  of the s3 bucket used to store the useraction harvester's last action timestamp 
+  value. Only relevant for analytics node and only affects new clusters. Also 
+  bumped harvest batch size from the default 1000/per
+
 ## 1.5.0 - 6/10/2016
 
 * Configuration for the new Matterhorn aws s3 file archive service (s3 bucket name).

--- a/recipes/install-ua-harvester.rb
+++ b/recipes/install-ua-harvester.rb
@@ -47,7 +47,7 @@ AWS_DEFAULT_REGION="#{region}"
 MATTERHORN_REST_USER="#{rest_auth_info[:user]}"
 MATTERHORN_REST_PASS="#{rest_auth_info[:pass]}"
 MATTERHORN_HOST="#{engage_node[:private_ip]}"
-S3_LAST_ACTION_TS_BUCKET=mh-user-action-harvester
+S3_LAST_ACTION_TS_BUCKET="#{stack_name}-ua-harvester"
 S3_LAST_ACTION_TS_KEY="#{stack_name}-last-action-ts"
 SQS_QUEUE_NAME="#{sqs_queue_name}"
 LOGGLY_TAGS="#{stack_name}"
@@ -65,7 +65,7 @@ end
 cron_d 'ua_harvester' do
   user 'ua_harvester'
   minute '*/2'
-  command %Q(cd /home/ua_harvester/harvester && /usr/bin/run-one ./ua_harvest.py 2>&1 | logger -t info)
+  command %Q(cd /home/ua_harvester/harvester && /usr/bin/run-one ./ua_harvest.py -b 10000 2>&1 | logger -t info)
   path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 end
 


### PR DESCRIPTION
I'd been using a single bucket with s3 objects differentiated by cluster name. This was backwards (duh) as you can't re-use a bucket across accounts (dce-deac vs dce-deac-test).