### PR TITLE
MATT-2103-two-week-pending-tasks Added stack name to config.properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TO BE RELEASED
 
+## 1.7.0 - 7/5/2016
+
+* Added stack short name to config.properties so that we can show the cluster name when sending notification emails.  
+
 ## 1.6.0 - 6/24/2016
 
 * Configuration for the newrelic is now different for each layer (admin,work,engage)

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -10,6 +10,7 @@ storage_info = get_storage_info
 shared_storage_root = get_shared_storage_root
 rest_auth_info = get_rest_auth_info
 admin_user_info = get_admin_user_info
+stack_name = stack_shortname
 
 capture_agent_query_url = node.fetch(
   :capture_agent_query_url, 'http://example.com'
@@ -125,6 +126,7 @@ deploy_revision "matterhorn" do
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,
         job_maxload: nil,
+        stack_name: stack_name,
       })
     end
   end

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -10,6 +10,7 @@ storage_info = get_storage_info
 shared_storage_root = get_shared_storage_root
 rest_auth_info = get_rest_auth_info
 admin_user_info = get_admin_user_info
+stack_name = stack_shortname
 
 capture_agent_query_url = node.fetch(
   :capture_agent_query_url, 'http://example.com'
@@ -135,6 +136,7 @@ deploy_revision "matterhorn" do
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,
         job_maxload: nil,
+        stack_name: stack_name,
       })
     end
   end

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -10,6 +10,7 @@ storage_info = get_storage_info
 shared_storage_root = get_shared_storage_root
 rest_auth_info = get_rest_auth_info
 admin_user_info = get_admin_user_info
+stack_name = stack_shortname
 
 capture_agent_query_url = node.fetch(
   :capture_agent_query_url, 'http://example.com'
@@ -127,6 +128,7 @@ deploy_revision "matterhorn" do
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,
         job_maxload: nil,
+        stack_name: stack_name,
       })
     end
   end

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -10,6 +10,7 @@ storage_info = get_storage_info
 shared_storage_root = get_shared_storage_root
 rest_auth_info = get_rest_auth_info
 admin_user_info = get_admin_user_info
+stack_name = stack_shortname
 
 capture_agent_query_url = node.fetch(
   :capture_agent_query_url, 'http://example.com'
@@ -118,6 +119,7 @@ deploy_revision "matterhorn" do
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_streaming_url: live_streaming_url,
         job_maxload: 4,
+        stack_name: stack_name,
       })
     end
   end

--- a/templates/default/config.properties.erb
+++ b/templates/default/config.properties.erb
@@ -226,3 +226,6 @@ org.opencastproject.server.maxload=<%= @job_maxload %>
 #DCE Email address to send notifications to
 edu.harvard.dce.notification.email=devel@lists.dce.harvard.edu
 
+#DCE Cluster name 
+edu.harvard.dce.cluster.name=<%= @stack_name %>
+


### PR DESCRIPTION
This was added to allow showing the cluster name in the subject of notification emails.