### PR TITLE
mo-scaler updates + queued jobs metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## TO BE RELEASED
 
+* *REQURES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:
+  Changes to moscaler configuration deployment. Updated config will be detailed in the MH release notes.
+  After an `update_chef_recipes` do a manual recipe exec:
+
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Ganglia" recipes="mh-opsworks-recipes::install-moscaler"
+        
+* *REQURES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:
+  Fixes to the recipe/script that provides the MatterhornJobsQueue metric. Cluster config
+  should be updated to include the `install-job-queued-metrics` recipe. See MH release notes for more deets.
+  After an `update_chef_recipes` do
+  a manual recipe exec:
+
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Ganglia" recipes="mh-opsworks-recipes::install-job-queued-metrics"
+
+
 ## 1.9.0 - 7/21/2016
 
 * *REQUIRES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:

--- a/files/default/queued_job_count.py
+++ b/files/default/queued_job_count.py
@@ -18,19 +18,22 @@ def main(args):
     # then get their running operations
     running_ops = []
     for wf in running_wfs:
-        running_ops.extend(filter(
-            lambda x: x.state in ["RUNNING","WAITING"],
-            wf.operations
-        ))
+        running_ops.extend([
+            x for x in wf.operations
+            if x.state in ["RUNNING", "WAITING"]
+        ])
 
     # filter for the operation types we're interested in
-    if args.type is not None:
-        running_ops = filter(lambda x: x.id in args.type, running_ops)
+    if args.type:
+        running_ops = [x for x in running_ops if x.id in args.type]
 
     # now get any queued child jobs of those operations
     queued_jobs = []
     for op in running_ops:
-        queued_jobs.extend(filter(lambda x: x.status == "QUEUED", op.job.children))
+        queued_jobs.extend([
+            x for x in op.job.children
+            if x.status == 'QUEUED'
+        ])
 
     print len(queued_jobs)
 
@@ -40,9 +43,7 @@ if __name__ == '__main__':
     parser.add_argument('host', help='Matterhorn host (including scheme)')
     parser.add_argument('-u','--username', help='Matterhorn system user')
     parser.add_argument('-p','--password', help='Matterhorn system user password')
-    parser.add_argument('-t','--type', action='append',
-                        help="Operation types to care about",
-                        default=['editor','compose','inspect','video-segment'])
+    parser.add_argument('-t','--type', action='append', help="Operation types to care about")
 
     args = parser.parse_args()
     main(args)

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -424,24 +424,19 @@ module MhOpsworksRecipes
     
     def get_moscaler_info
       {
-          'moscaler_strategy' => 'disabled', 
+          'moscaler_type' => 'disabled',
           'moscaler_release' => 'v1.0.0',
           'moscaler_debug' => false,
           'offpeak_instances' => 2,
           'peak_instances' => 10,
           'weekend_instances' => 1,
           'cron_interval' => '*/2',
-          'autoscale_up_increment' => 2,
-          'autoscale_down_increment' => 1,
-          'autoscale_up_threshold' => 12.0,
-          'autoscale_down_threshold' => 8.0,
-          'autoscale_type' => 'LayerLoad',
-          'autoscale_layerload_metric' => 'load_1',
-          'autoscale_layerload_sample_count' => 3,
-          'autoscale_layerload_sample_period' => 60,
           'min_workers' => 1,
           'idle_uptime_threshold' => 50,
-          'autoscale_pause_interval' => 300
+          'autoscale_up_increment' => 2,
+          'autoscale_down_increment' => 1,
+          'autoscale_pause_cycles' => 1,
+          'autoscale_strategies' => []
         }.merge(node.fetch(:moscaler, {}))
     end
   end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -425,7 +425,7 @@ module MhOpsworksRecipes
     def get_moscaler_info
       {
           'moscaler_type' => 'disabled',
-          'moscaler_release' => 'v1.0.0',
+          'moscaler_release' => 'v1.1.0',
           'moscaler_debug' => false,
           'offpeak_instances' => 2,
           'peak_instances' => 10,

--- a/recipes/install-job-queued-metrics.rb
+++ b/recipes/install-job-queued-metrics.rb
@@ -3,17 +3,17 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 ::Chef::Resource::RubyBlock.send(:include, MhOpsworksRecipes::RecipeHelpers)
-python_pip "pyhorn" do
-  version "0.4.1"
-end
+
+install_package('python-pip')
 
 rest_auth_info = get_rest_auth_info
 aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
 (private_admin_hostname, admin_attributes) = node[:opsworks][:layers][:admin][:instances].first
 
-# This should probably be less than the number of jobs matterhorn assigns to a
-# worker, or we could have some jobs that wait a while for a worker.
-scale_up_limit = node.fetch(:scale_up_when_queued_jobs_gt, 3)
+bash 'install pyhorn' do
+  code 'pip install pyhorn==0.8.0'
+  user 'root'
+end
 
 cookbook_file "queued_job_count.py" do
   path "/usr/local/bin/queued_job_count.py"
@@ -34,15 +34,4 @@ cron_d 'matterhorn_jobs_queued' do
   minute '*'
   command %Q(/usr/local/bin/queued_job_count_metric.sh "#{aws_instance_id}" "http://#{private_admin_hostname}/" "#{rest_auth_info[:user]}" "#{rest_auth_info[:pass]}" 2>&1 | logger -t info)
   path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-end
-
-ruby_block "add up alarm for matterhorn job queued based scaling" do
-  block do
-    aws_instance_id = node[:opsworks][:instance][:aws_instance_id]
-    region = 'us-east-1'
-
-    command = %Q(aws cloudwatch put-metric-alarm --region "#{region}" --alarm-name "#{topic_name}_jobs_queued_high" --alarm-description "Many matterhorn jobs to process" --metric-name MatterhornJobsQueued --namespace AWS/OpsworksCustom --statistic Average --period 180 --threshold #{scale_up_limit} --comparison-operator GreaterThanThreshold --dimensions Name=InstanceId,Value=#{aws_instance_id} --evaluation-periods 1 --no-actions-enabled)
-    Chef::Log.info command
-    execute_command(command)
-  end
 end


### PR DESCRIPTION
Lumping these commits together as they are closely related.

The mo-scaler configuration has changed dramatically to allow monitoring of multiple cloudwatch metrics as well as other sources of info. Therefore the configuration deployment needed to change. Gone are most of the `AUTOSCALE_...` env vars, replaced with a json config file which is generated by the recipe based on the `moscaler` settings in the cluster config. 

Also, I've resuscitated and updated a recipe that generates a `MatterhornJobsQueeu` cloudwatch metric. This will hopefully be the (or one of the) metrics that the horizontal scaling takes into consideration for scaling up/down.