### PR TITLE
Allow autofs restart if `storage_hostname` differs from current mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   Additional helpful utils to be installed by default
   
         ./bin/rake stack:commands:execute_recipes_on_layers recipes="mh-opsworks-recipes::install-utils"
+* prevent autofs restart only if existing mount matches the storage hostname. this
+  enables use of the `nfs-client` recipe for switching storage nodes or zadara vpsas
 
 ## 1.10.0 - 8/12/2016
 

--- a/recipes/nfs-client.rb
+++ b/recipes/nfs-client.rb
@@ -47,7 +47,7 @@ end
 # Only restart if we don't have an active mount
 service 'autofs' do
   action :restart
-  not_if %Q|grep ' #{export_root} ' /proc/mounts|
+  not_if %Q|grep '#{storage_hostname}:#{export_root} ' /proc/mounts|
 end
 
 execute 'warm directory' do


### PR DESCRIPTION
This allows the `nfs-client` recipe to restart autofs in the situation where the storage hostname has changed. This would happen in the case of a storage node or VPSA swap.