### PR TITLE
`moscaler_release` should default to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* `moscaler_release` now defaults to "master"
+
 ## 1.10.0 - 8/12/2016
 
 * *REQURES EDITS TO THE CLUSTER CONFIG* *REQUIRES MANUAL CHEF RECIPE RUNS*:

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -425,7 +425,7 @@ module MhOpsworksRecipes
     def get_moscaler_info
       {
           'moscaler_type' => 'disabled',
-          'moscaler_release' => 'v1.1.0',
+          'moscaler_release' => 'master',
           'moscaler_debug' => false,
           'offpeak_instances' => 2,
           'peak_instances' => 10,


### PR DESCRIPTION
Specific release tags should be set in the cluster config.