### PR TITLE
cam-20-timedrift: install cronjob to poll time in CAs

### DIFF
--- a/recipes/install-ca-timedrift-metric.rb
+++ b/recipes/install-ca-timedrift-metric.rb
@@ -1,0 +1,37 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-ca-timedrift-metric
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+capture_agent_manager_info = get_capture_agent_manager_info
+app_name = get_capture_agent_manager_app_name
+usr_name = get_capture_agent_manager_usr_name
+
+template %Q|/usr/local/bin/ca_timedrift.sh| do
+  source 'ca-timedrift-metric-script.erb'
+  mode "0755"
+  manage_symlink_source true
+  variables({
+    ca_stats_user: capture_agent_manager_info[:ca_stats_user],
+    ca_stats_passwd: capture_agent_manager_info[:ca_stats_passwd],
+    ca_stats_json_url: capture_agent_manager_info[:ca_stats_json_url]
+  })
+end
+
+# install ssh key to capture agents
+file "/home/#{usr_name}/.ssh/dce-epiphan" do
+  owner usr_name
+  group usr_name
+  content capture_agent_manager_info[:ca_private_ssh_key]
+  mode '0600'
+end
+
+
+cron_d "ca_timedrift_metrics" do
+  user usr_name
+  minute "*/15"
+  # Redirect stderr and stdout to logger. The command is silent on succesful runs
+  command %Q(/usr/local/bin/ca_timedrift.sh 2>&1 | logger -t info)
+  path "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+end
+

--- a/templates/default/ca-timedrift-metric-script.erb
+++ b/templates/default/ca-timedrift-metric-script.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+namespace="DECustom"
+region="us-east-1"
+metric_name="CA-timedrift"
+dimension_name="CAName"
+
+ca_list=$(curl -v --user "<%= @ca_stats_user %>:<%= @ca_stats_passwd %>" "<%= @ca_stats_json_url %>" | grep address | awk  -F'"' '{print $4;}' | awk -F. '{print $1;}')
+
+for ca in ${ca_list}
+do
+    metric=$(echo "`date -u +%s` - `ssh -o 'StrictHostKeyChecking no' -i ${HOME}/.ssh/dce-epiphan root@${ca}.dce.harvard.edu date -u +%s`" | bc)
+    /usr/local/bin/aws cloudwatch put-metric-data --namespace ${namespace} --region ${region} --metric-name ${metric_name} --unit "Seconds" --value "${metric}" --dimensions "${dimension_name}=${ca}"
+    sleep 1  # to mitigate throttle in aws cloudwatch api
+done
+


### PR DESCRIPTION
publish metrics for timedrift in CA to cloudwatch.