### PR TITLE
MATT-2182-akamai-hack Added stream name override for byerly CA

### DIFF
--- a/templates/default/edu.harvard.dce.live.impl.LiveServiceImpl.properties.erb
+++ b/templates/default/edu.harvard.dce.live.impl.LiveServiceImpl.properties.erb
@@ -15,3 +15,8 @@ live.resolution=1920x540,960x270
 live.stream-name=<%= @live_stream_name %>
 
 live.download-source-flavors=dublincore/*
+
+# MATT-2182-akamai-hack
+# If we want to override a stream name for a capture agent, add it here e.g.
+live.stream-name-override.byerly-013=#{caName}-#{flavor}.stream-#{resolution}_1_200@387916
+


### PR DESCRIPTION
The byerly CA is hard-coded to stream to the other akamai ID in the live config file.