### PR TITLE
MATT-2173 remove submodule init

### DIFF
--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -60,7 +60,6 @@ deploy_revision "matterhorn" do
   deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
-  enable_submodules true
 
   user 'matterhorn'
   group 'matterhorn'

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -65,7 +65,6 @@ deploy_revision "matterhorn" do
   deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
-  enable_submodules true
 
   user 'matterhorn'
   group 'matterhorn'

--- a/recipes/deploy-database.rb
+++ b/recipes/deploy-database.rb
@@ -23,7 +23,6 @@ deploy_revision "matterhorn" do
   deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
-  enable_submodules true
 
   user 'matterhorn'
   group 'matterhorn'

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -61,7 +61,6 @@ deploy_revision "matterhorn" do
   deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
-  enable_submodules true
 
   user 'matterhorn'
   group 'matterhorn'

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -53,7 +53,6 @@ deploy_revision "matterhorn" do
   deploy_to matterhorn_repo_root
   repo repo_url
   revision git_data.fetch(:revision, 'master')
-  enable_submodules true
 
   user 'matterhorn'
   group 'matterhorn'


### PR DESCRIPTION
This removes the submodule init from the deploy. Paella player module source files are now directly available in the module and no longer retrieved from a submodule. (The source files are pre-compiled from all its dependencies during the dev phase).