### PR TITLE
add `retries` to setting of cloudwatch retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TO BE RELEASED
 
+* add `retries` to setting of cloudwatch log retention to avoid race condition
+  when previous log group creation is still processing
+
 ## 1.14.0 - 10/28/2016
 
 * *REQUIRES EDITS TO CLUSTER CONFIG*

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -486,6 +486,8 @@ module MhOpsworksRecipes
 
       execute 'set log group retention policy' do
         command %Q|aws logs put-retention-policy --region #{region} --log-group-name #{log_group_name} --retention-in-days #{retention_days}|
+        retries 3
+        retry_delay 10
       end
 
       template "/var/awslogs/etc/config/#{log_name}.conf" do


### PR DESCRIPTION
this avoids the race condition that can occur when AWS is still dealing
with the preceeding log group creation command