### PR TITLE
MATT-2172-link-errors Changed location of zip tmp directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * *REQUIRES EDITS TO CLUSTER CONFIG*
   Configuration for the new Matterhorn ibm watson transcription service (service credentials).
+* Changed location of temporary zip files to Zadara to avoid cross-device link errors. Zip operations are executed when republishing and failing a workflow. 
 
 ## 1.14.1 - 11/03/2016
 

--- a/templates/default/config.properties.erb
+++ b/templates/default/config.properties.erb
@@ -210,6 +210,14 @@ org.opencastproject.textanalyzer.tesseract.path=/usr/bin/tesseract
 # Email address of the server's admin.
 org.opencastproject.admin.email=admin@localhost
 
+# Location of the temporary directory to build zip archives. Defaults to
+# ${org.opencastproject.storage.dir}/archive-tmp
+org.opencastproject.workflow.handler.ZipWorkflowOperationHandler.tmpdir=<%= @shared_storage_root %>/zip-tmp
+
+# Location of the temporary directory to build zip for republishings. Defaults to
+# ${org.opencastproject.storage.dir}/dce-tmp
+edu.harvard.dce.operation.handler.RepublishRecordingWorkflowOperationHandler.tmpdir=<%= @shared_storage_root %>/dce-republish-tmp 
+
 org.opencastproject.captureagent_monitor_url=<%= @capture_agent_monitor_url %>
 
 #DCE Phoebe - to fetch any config use: /info/configuration/<config name>.json


### PR DESCRIPTION
This moves the temporary directory used by zip operations to Zadara, eliminating the cross-device link errors we currently see in the logs and making republishing more efficient because of hard-linking (another zip operation is also used when failing a workflow hence the two places in the config).