### PR TITLE
Enable dynamic scripting in elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Configuration for the new Matterhorn ibm watson transcription service (service credentials).
 * Changed location of temporary zip files to Zadara to avoid cross-device link errors. Zip operations are executed when republishing and failing a workflow. 
 * MATT-2215 add threshold config params to log connection durations in hudce-auth and leg-otherpubs (sys web msg)
+* *REQUIRES MANUAL RECIPE RUN*
+  Enable dynamic scripting in `elasticsearch.yml`
 
 ## 1.14.1 - 11/03/2016
 

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -21,3 +21,7 @@ node.local: true
 
 # cloud-aws settings
 cloud.aws.region: <%= @aws_region %>
+
+# enable dynamic scripting
+script.inline: true
+script.indexed: true


### PR DESCRIPTION
Disabled by default because of security issues, but we run a tightly restricted ES (private IP, secure proxy, etc) so this is safe to enable. Allows for more powerful aggregation filters/queries, e.g. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-selector-aggregation.html