### PR TITLE
crowdstrike install recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## TO BE RELEASED
 
 * skip cloudwatch log setup for local clusters; fix rsyslog restart (MATT-2238)
+* *REQUIRES MANUAL RECIPE RUN* Crowdstrike falcon host installation.
+  The following command is an example of what would be run on the prod cluster. For dev clusters,
+  adjust the `layers` list according to what nodes are present.
 
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin,Engage,Utility,Storage,Analytics" recipes="mh-opsworks-recipes::install-crowdstrike"
+        
 ## v1.16.0 - 12/8/2016
 
 * *REQUIRES EDITS TO EXISTING CLUSTER CONFIG*

--- a/metadata.rb
+++ b/metadata.rb
@@ -972,6 +972,20 @@ recipe(
 * creates log stream configurations for syslog, matterhorn.log and nginx logs on appropriate nodes
 '
 )
+recipe(
+    'mh-opsworks-recipes::install-crowdstrike',
+    'Installs the CrowdStrike Falcon Sensor software. Because security.
+
+=== attributes
+none
+
+=== effects
+* installs a stand-alone .deb file from our mh-opsworks-shared-assets bucket
+* installs to /opt/CrowdStrike
+* includes apt package dependencies: auditd, libauparse0
+* auditd log rotation is configured in /etc/audit.conf (which is modiified by the CrowdStrike package)
+'
+)
 
 depends 'nfs', '~> 2.1.0'
 depends 'apt', '~> 2.9.2'

--- a/recipes/install-crowdstrike.rb
+++ b/recipes/install-crowdstrike.rb
@@ -1,0 +1,30 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-crowdstrike
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+include_recipe "mh-opsworks-recipes::update-package-repo"
+
+bucket_name = get_shared_asset_bucket_name
+crowdstrike_deb = node.fetch(:crowdstrike_deb, 'falcon-sensor_2.0.22-1202_amd64.deb')
+crowdstrike_version = node.fetch(:crowdstrike_version, '2.0.0022.1202')
+::Chef::Log.info("crowdstrike version #{crowdstrike_version}")
+
+if on_aws?
+  install_package("auditd libauparse0")
+  include_recipe "mh-opsworks-recipes::install-awscli"
+  download_command="/usr/local/bin/aws s3 cp s3://#{bucket_name}/#{crowdstrike_deb} ."
+
+  bash 'install crowdstrike falcon host pacakge' do
+    code %Q|
+cd /opt &&
+/bin/rm -f #{crowdstrike_deb} &&
+#{download_command} &&
+dpkg -i #{crowdstrike_deb}
+|
+    retries 5
+    retry_delay 10
+    timeout 300
+    # don't install if the install dir is present AND the version matches
+    not_if "test -d /opt/CrowdStrike && /opt/CrowdStrike/CsConfig -g --version | /bin/grep -q -F '#{crowdstrike_version}.'"
+  end
+end


### PR DESCRIPTION
Installs the crowdstrike falcon host as mandated by HUIT.

Allows for a `crowdstrike_deb` and `crowdstrike_version` option in the stack's custom json, but defaults should be good for awhile.