### PR TITLE
MATT-2232-L01-stream-id Configured L01 to point to the second Akamai id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v1.17.0 - 01/10/2017
 
+* update CA hack: 53chur-l01 now points to new prod akami stream id (same as byerly)
 * skip cloudwatch log setup for local clusters; fix rsyslog restart (MATT-2238)
 * *REQUIRES MANUAL RECIPE RUN* Crowdstrike falcon host installation.
   The following command is an example of what would be run on the prod cluster. For dev clusters,

--- a/templates/default/edu.harvard.dce.live.impl.LiveServiceImpl.properties.erb
+++ b/templates/default/edu.harvard.dce.live.impl.LiveServiceImpl.properties.erb
@@ -19,4 +19,5 @@ live.download-source-flavors=dublincore/*
 # MATT-2182-akamai-hack
 # If we want to override a stream name for a capture agent, add it here e.g.
 live.stream-name-override.byerly-013=#{caName}-#{flavor}.stream-#{resolution}_1_200@387916
+live.stream-name-override.53chur-l01=#{caName}-#{flavor}.stream-#{resolution}_1_200@387916
 


### PR DESCRIPTION
Configuration for L01 classroom to support the secondaries, which still have MHPearl 2.0, or in the case we rollback the primaries.