### PR TITLE
include auth key in auth properties file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TO BE RELEASED
 
+* *REQUIRES EDITS TO CLUSTER CONFIG* 
+  include auth key when deploying mh auth properties file. `auth_key` value must be
+  added to prod cluster config prior to deployment.
+
 ## v1.18.0 - 01/19/2017
 
 * *REQUIRES EDITS TO EXISTING CLUSTER CONFIG*

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -949,7 +949,7 @@ module MhOpsworksRecipes
       end
     end
 
-    def install_auth_service(current_deploy_root, auth_host, redirect_location, auth_activated = 'true')
+    def install_auth_service(current_deploy_root, auth_host, redirect_location, auth_key, auth_activated = 'true')
       template %Q|#{current_deploy_root}/etc/services/edu.harvard.dce.auth.impl.HarvardDCEAuthServiceImpl.properties| do
         source 'edu.harvard.dce.auth.impl.HarvardDCEAuthServiceImpl.properties.erb'
         owner 'matterhorn'
@@ -957,7 +957,8 @@ module MhOpsworksRecipes
         variables({
           auth_host: auth_host,
           redirect_location: redirect_location,
-          auth_activated: auth_activated
+          auth_activated: auth_activated,
+          auth_key: auth_key
         })
       end
     end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -42,6 +42,7 @@ live_stream_name = get_live_stream_name
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_activated = node.fetch(:auth_activated, 'true')
+auth_key = node.fetch(:auth_key, '')
 
 git_data = node[:deploy][:matterhorn][:scm]
 
@@ -97,7 +98,7 @@ deploy_revision "matterhorn" do
     install_smtp_config(most_recent_deploy)
     install_default_tenant_config(most_recent_deploy, public_admin_hostname, private_hostname)
     install_auth_service(
-      most_recent_deploy, auth_host, auth_redirect_location, auth_activated
+      most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     # Admin Specific

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -48,6 +48,7 @@ live_stream_name = get_live_stream_name
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_activated = node.fetch(:auth_activated, 'true')
+auth_key = node.fetch(:auth_key, '')
 
 git_data = node[:deploy][:matterhorn][:scm]
 
@@ -104,7 +105,7 @@ deploy_revision "matterhorn" do
     install_smtp_config(most_recent_deploy)
     install_default_tenant_config(most_recent_deploy, public_hostname, private_hostname)
     install_auth_service(
-      most_recent_deploy, auth_host, auth_redirect_location, auth_activated
+      most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -27,6 +27,7 @@ live_stream_name = get_live_stream_name
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_activated = node.fetch(:auth_activated, 'true')
+auth_key = node.fetch(:auth_key, '')
 
 ## Engage specific
 user_tracking_authhost = node.fetch(
@@ -91,7 +92,7 @@ deploy_revision "matterhorn" do
     install_smtp_config(most_recent_deploy)
     install_default_tenant_config(most_recent_deploy, public_engage_hostname, private_hostname)
     install_auth_service(
-      most_recent_deploy, auth_host, auth_redirect_location, auth_activated
+      most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_published_event_details_email(most_recent_deploy, public_engage_hostname)

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -28,6 +28,7 @@ live_stream_name = get_live_stream_name
 
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
+auth_key = node.fetch(:auth_key, '')
 
 auth_activated = node.fetch(:auth_activated, 'true')
 
@@ -82,7 +83,7 @@ deploy_revision "matterhorn" do
     remove_felix_fileinstall(most_recent_deploy)
     install_smtp_config(most_recent_deploy)
     install_auth_service(
-      most_recent_deploy, auth_host, auth_redirect_location, auth_activated
+      most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     install_published_event_details_email(most_recent_deploy, public_engage_hostname)

--- a/templates/default/edu.harvard.dce.auth.impl.HarvardDCEAuthServiceImpl.properties.erb
+++ b/templates/default/edu.harvard.dce.auth.impl.HarvardDCEAuthServiceImpl.properties.erb
@@ -4,6 +4,7 @@ dce.auth.servicePort=8080
 dce.auth.servicePath=/AuthMH
 dce.auth.redirectLocation=<%= @redirect_location %>
 dce.auth.activated=<%= @auth_activated %>
+dce.auth.key=<%= @auth_key %>
 # MATT-2215 Add log threshold for connection/read timeout in seconds
 dce.auth.connectiontimelogthreshold=0
 


### PR DESCRIPTION
This adds the dce auth key ("auth_key") to the cluster config settings that are included in the `edu.harvard.dce.auth.impl.HarvardDCEAuthServiceImpl.properties` file during deployment. 