### PR TITLE
adding request_time log format to engage proxy conf

### DIFF
--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -4,6 +4,11 @@ userid_expires max;
 
 log_format session_uid '$cookie_JSESSIONID $uid_got';
 
+log_format request_time '$remote_addr - $remote_user [$time_local] '
+                        '"$request" $status $bytes_sent '
+                        '"$http_referer" "$http_user_agent" '
+                        '$request_time $upstream_response_time';
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server ipv6only=on;


### PR DESCRIPTION
this is a hotfix change that corresponds to an existing live edit