### PR TITLE
Add GC logging and options for G1 garbage collection & YourKit jvm profiler agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 * redirect output from MH start-on-boot cron entry to syslog to prevent
   unnecessary emails
+* Allow enabling of G1 Garbage Collection method and YourKit profiler agent. Both are off by default. To enable, add either/both of the following attributes respectively to the cluster config's custom json:
 
+```
+    ...
+    "enable_G1GC": true,
+    ...
+    "enable_yourkit_agent": true,
+    ...
+```
+    
 # v1.22.0 - 04/21/2017
 
 * MI-63: remove nodejs install recipe as it is no longer needed

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -802,7 +802,10 @@ module MhOpsworksRecipes
           matterhorn_root: matterhorn_repo_root + '/current',
           felix_config_dir: matterhorn_repo_root + '/current/etc',
           matterhorn_log_directory: log_dir,
-          enable_newrelic: enable_newrelic?
+          enable_newrelic: enable_newrelic?,
+          enable_G1GC: enable_G1GC?,
+          enable_yourkit_agent: enable_yourkit_agent?,
+          yourkit_dir: matterhorn_repo_root + '/yourkit'
         })
       end
     end
@@ -883,6 +886,13 @@ module MhOpsworksRecipes
        nr_layers.key?(layer_name)
     end
 
+    def enable_yourkit_agent?
+      node[:enable_yourkit_agent]
+    end
+
+    def enable_G1GC?
+       node[:enable_G1GC] and node[:opsworks][:instance][:hostname].match(/^(admin|engage)/)
+    end
 
     def configure_newrelic(current_deploy_root, node_name, layer_name)
       if enable_newrelic_layer?(layer_name)

--- a/recipes/install-mh-base-packages.rb
+++ b/recipes/install-mh-base-packages.rb
@@ -12,4 +12,5 @@ end
 packages = %Q|autofs5 curl dkms gzip jq libglib2.0-dev maven mediainfo mysql-client openjdk-7-jdk openjdk-7-jre postfix python-pip rsyslog-gnutls run-one tesseract-ocr|
 install_package(packages)
 
+include_recipe "mh-opsworks-recipes::install-yourkit-agent"
 include_recipe "mh-opsworks-recipes::clean-up-package-cache"

--- a/recipes/install-yourkit-agent.rb
+++ b/recipes/install-yourkit-agent.rb
@@ -1,0 +1,25 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: install-yourkit
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+matterhorn_repo_root = node[:matterhorn_repo_root]
+shared_assets_bucket = get_shared_asset_bucket_name
+agent_url = "https://s3.amazonaws.com/#{shared_assets_bucket}/libyjpagent.so"
+yourkit_dir = "#{matterhorn_repo_root}/yourkit"
+agent_filepath = "#{yourkit_dir}/libyjpagent.so"
+
+directory yourkit_dir do
+  owner 'matterhorn'
+  group 'matterhorn'
+  mode '0755'
+end
+
+remote_file agent_filepath do
+  source agent_url
+  action :create_if_missing
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+

--- a/templates/default/matterhorn-harness.erb
+++ b/templates/default/matterhorn-harness.erb
@@ -145,7 +145,19 @@ NEWRELIC="-javaagent:${NEW_RELIC_JAR} $NEWRELIC_CONFIG"
 NEWRELIC=""
 <% end %>
 
-MATTERHORN_OPTS="$NEWRELIC $GOSH $DEBUG $FELIX $GRAPHICS $JAVA $LOGGING $JMX $DISABLE_PHONEHOME $ADD_OPTS"
+<% if @enable_yourkit_agent %>
+YOURKIT="-agentpath:<%= @yourkit_dir %>/libyjpagent.so=dir=<%= @yourkit_dir %>,onlylocal"
+<% end %>
+
+GC="-Xloggc:${LOGDIR}/gcnormal.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
+GC="${GC} -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintHeapAtGC"
+GC="${GC} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=20 -XX:GCLogFileSize=32M"
+
+<% if @enable_G1GC %>
+GC="${GC} -XX:+UseG1GC"
+<% end %>
+
+MATTERHORN_OPTS="$NEWRELIC $GOSH $DEBUG $FELIX $GRAPHICS $JAVA $LOGGING $DISABLE_PHONEHOME $JMX $GC $YOURKIT $ADD_OPTS"
 
 # Execute Capture-Agent device configuration
 $IS_CA && $CA/device_config.sh


### PR DESCRIPTION
This PR add GC logging to our MH java start options. This is unobtrusive and will give us a bit more insight into JVM behavior.

The PR also adds a couple of cluster config options that allow to things.

* enabling the G1 garbage collection algorithm. Good overview of that [here](http://product.hubspot.com/blog/g1gc-fundamentals-lessons-from-taming-garbage-collection).
* including the [YourKit](https://www.yourkit.com/java/profiler/features/) java profiling agent to the MH startup options. This is intended only for enabling on a dev cluster and has no effect if not enabled.
