### PR TITLE
capture mh start-on-boot cron output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TO BE RELEASED
 
+* redirect output from MH start-on-boot cron entry to syslog to prevent
+  unnecessary emails
+
 # v1.22.0 - 04/21/2017
 
 * MI-63: remove nodejs install recipe as it is no longer needed

--- a/recipes/register-matterhorn-to-boot.rb
+++ b/recipes/register-matterhorn-to-boot.rb
@@ -8,5 +8,5 @@ cron_d 'start_matterhorn_at_boot' do
   # frustrating.
   path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games'
   predefined_value '@reboot'
-  command '/etc/init.d/matterhorn start'
+  command '/etc/init.d/matterhorn start 2>&1 | /usr/bin/logger -t info'
 end


### PR DESCRIPTION
This is a very minor, no rush change. While looking into producer notification delays I noticed errors in the worker mail logs. Turns they're trying to email the output of the `/etc/init.d/matterhorn start` that runs on boot.