### PR TITLE
fix for cloudwatch logs agent installer:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     ...
 ```
 * set JVM `-Xxms` value based on ratio to`-Xxmx` depending on node type
+* fetch `awslogs-agent-setup.py` cloudwatch logs setup script from shared assets bucket to ensure working/tested version
 
 # v1.22.0 - 04/21/2017
 

--- a/recipes/install-cwlogs.rb
+++ b/recipes/install-cwlogs.rb
@@ -4,6 +4,7 @@
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
 region = node[:opsworks][:instance][:region]
+shared_assets_bucket = get_shared_asset_bucket_name
 
 service 'awslogs' do
   action :nothing
@@ -23,7 +24,7 @@ directory '/opt/aws/cloudwatch' do
 end
 
 remote_file '/opt/aws/cloudwatch/awslogs-agent-setup.py' do
-  source 'https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py'
+  source %Q|https://s3.amazonaws.com/#{ shared_assets_bucket }/awslogs-agent-setup.py|
   mode '0755'
 end
 

--- a/recipes/install-mh-base-packages.rb
+++ b/recipes/install-mh-base-packages.rb
@@ -9,7 +9,7 @@ package "maven2" do
   ignore_failure true
 end
 
-packages = %Q|autofs5 curl dkms gzip jq libglib2.0-dev maven mediainfo mysql-client openjdk-7-jdk openjdk-7-jre postfix python-pip rsyslog-gnutls run-one tesseract-ocr|
+packages = %Q|autofs5 curl dkms gzip jq libglib2.0-dev maven mediainfo mysql-client openjdk-7-jdk openjdk-7-jre postfix python-pip python-dev rsyslog-gnutls run-one tesseract-ocr|
 install_package(packages)
 
 include_recipe "mh-opsworks-recipes::install-yourkit-agent"


### PR DESCRIPTION
* fetch from our shared assets bucket to ensure correct, tested version
* add `python-dev` to base packages as it's a dependency of latest agent
installer script