### PR TITLE
MATT-2355-workspace-cleaner 

### DIFF
--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -143,6 +143,7 @@ deploy_revision "matterhorn" do
         live_monitor_url: live_monitor_url,
         job_maxload: nil,
         stack_name: stack_name,
+        workspace_cleanup_period: 86400,
       })
     end
   end

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -131,6 +131,7 @@ deploy_revision "matterhorn" do
         live_streaming_url: live_streaming_url,
         job_maxload: nil,
         stack_name: stack_name,
+        workspace_cleanup_period: 0,
       })
     end
   end

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -120,6 +120,7 @@ deploy_revision "matterhorn" do
         live_streaming_url: live_streaming_url,
         job_maxload: 4,
         stack_name: stack_name,
+        workspace_cleanup_period: 0,
       })
     end
   end

--- a/templates/default/config.properties.erb
+++ b/templates/default/config.properties.erb
@@ -163,7 +163,8 @@ org.opencastproject.file.repo.url=<%= @admin_url %>
 org.opencastproject.workspace.rootdir=${org.opencastproject.shared_storage.dir}/workspace
 
 # The scheduled period in seconds, at which a workspace cleanup operation is performed
-org.opencastproject.workspace.cleanup.period=86400
+# org.opencastproject.workspace.cleanup.period=86400
+org.opencastproject.workspace.cleanup.period=<%= @workspace_cleanup_period %>
 
 # The maximum age a file must reach in seconds before a deletion of the file in the workspace cleanup operation is performed
 org.opencastproject.workspace.cleanup.max.age=2592000


### PR DESCRIPTION
Disable workspace cleaner on nodes depending on configuration. The idea is that only admin will run the ws cleaner in the future but, for this week, we need to disable it on all nodes.