### PR TITLE
MATT-2353-repub-problems Change location of tmp repub dir

### DIFF
--- a/templates/default/config.properties.erb
+++ b/templates/default/config.properties.erb
@@ -216,7 +216,7 @@ org.opencastproject.workflow.handler.ZipWorkflowOperationHandler.tmpdir=<%= @sha
 
 # Location of the temporary directory to build zip for republishings. Defaults to
 # ${org.opencastproject.storage.dir}/dce-tmp
-edu.harvard.dce.operation.handler.RepublishRecordingWorkflowOperationHandler.tmpdir=<%= @shared_storage_root %>/dce-republish-tmp 
+edu.harvard.dce.operation.handler.RepublishRecordingWorkflowOperationHandler.tmpdir=<%= @local_workspace_root %>/dce-republish-tmp 
 
 org.opencastproject.captureagent_monitor_url=<%= @capture_agent_monitor_url %>
 


### PR DESCRIPTION
Workarounds because of Zadara problems. These changes were made directly in production. This PR will include them in the next release.