### PR TITLE
OPC-42-fix-nginx-temp-file-path

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -346,6 +346,11 @@ module MhOpsworksRecipes
       )
     end
 
+    def get_nginx_body_temp_path
+      %Q|#{get_shared_storage_root}/nginx/body-temp|
+    end
+
+
     def allow_opencast_user_to_restart_daemon_via_sudo
       file '/etc/sudoers.d/opencast' do
         owner 'root'

--- a/recipes/configure-nginx-proxy.rb
+++ b/recipes/configure-nginx-proxy.rb
@@ -7,8 +7,7 @@ install_package('nginx')
 
 install_nginx_logrotate_customizations
 
-# save nginx temp big upload video block cache to Zadara array
-body_temp_path = get_shared_storage_root + "/nginx/body-temp"
+body_temp_path = get_nginx_body_temp_path
 
 template %Q|/etc/nginx/sites-enabled/default| do
   source 'nginx-proxy.conf.erb'
@@ -22,15 +21,6 @@ end
 directory '/etc/nginx/proxy-includes' do
   owner 'root'
   group 'root'
-end
-
-# same permissions as nginx logs
-directory  %Q|#{body_temp_path}| do
-  action :create
-  owner 'www-data'
-  group 'admin'
-  mode '755'
-  recursive true
 end
 
 execute 'service nginx reload'

--- a/recipes/create-opencast-directories.rb
+++ b/recipes/create-opencast-directories.rb
@@ -22,3 +22,13 @@
     recursive true
   end
 end
+
+# create path for nginx to buffer large uploads
+directory get_nginx_body_temp_path do
+  action :create
+  owner 'www-data'
+  group 'admin'
+  mode '755'
+  recursive true
+end
+


### PR DESCRIPTION
It works. The last oddity is that get_nginx_body_temp_path had to be retrieved outside of the variables block in configure-nginx-proxy.rb in order to be found in configure-nginx-proxy.rb. Putting get_nginx_body_temp_path directly inside the variable block caused "undefined method get_nginx_body_temp_path for Chef::Resource::Template". 
