### PR TITLE
recipes to pause/resume moscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Allow exit status of '255' on cloudwatch log group creation to get rid of errors due to ResourceAlreadyExistsException
 * cloudwatch logs agent install requires python-dev package
+* refactor of moscaler install to allow separate recipes for creating/removing cron_d resources.
+  this is to facilitate moscaler pause/resume rake tasks in `mh-opsworks`.
 
 ## v1.25.0 - 08/17/2017
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -997,6 +997,28 @@ none
 * performs an apt-get dist-upgrade
 '
 )
+recipe(
+    'mh-opsworks-recipes::moscaler-resume',
+    'Installs the moscaler cron entries
+
+=== attributes
+none
+
+=== effects
+* Installs the moscaler cron entries
+'
+)
+recipe(
+    'mh-opsworks-recipes::moscaler-pause',
+    'Removes the moscaler cron entries, effectively disabling moscaler
+
+=== attributes
+none
+
+=== effects
+* removes the moscaler cron entries
+'
+)
 
 depends 'nfs', '~> 2.1.0'
 depends 'apt', '~> 2.9.2'

--- a/recipes/install-moscaler.rb
+++ b/recipes/install-moscaler.rb
@@ -10,10 +10,6 @@ moscaler_attributes = get_moscaler_info
 Chef::Log.info moscaler_attributes
 
 moscaler_release = moscaler_attributes['moscaler_release']
-moscaler_type = moscaler_attributes['moscaler_type']
-debug_flag = moscaler_attributes['moscaler_debug'] ? '-d' : ''
-cron_interval = moscaler_attributes['cron_interval']
-autoscale_config = ''
 
 rest_auth_info = get_rest_auth_info
 stack_name = node[:opsworks][:stack][:name]
@@ -52,61 +48,15 @@ execute "Clean out existing cron jobs" do
   action :run  
 end
 
-if moscaler_type == 'time'
-  
-  offpeak_instances = moscaler_attributes['offpeak_instances']
-  peak_instances = moscaler_attributes['peak_instances']
-  weekend_instances = moscaler_attributes['weekend_instances']
-
-  # weekdays, offpeak, every five minutes from midnight - 7am + 11pm - midnight
-  cron_d 'moscaler_offpeak' do
-    user 'moscaler'
-    hour '0-7,23'
-    minute cron_interval
-    weekday '1-5'
-    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale to #{offpeak_instances} --scale-available 2>&1 | logger -t info)
-    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  end
-
-  # weekdays, normal production window, every five minutes from 8am - 11pm
-  cron_d 'moscaler_normal' do
-    user 'moscaler'
-    hour '8-22'
-    minute cron_interval
-    weekday '1-5'
-    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale to #{peak_instances} --scale-available 2>&1 | logger -t info)
-    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  end
-
-  # weekends, every five minutes
-  cron_d 'moscaler_weekend' do
-    user 'moscaler'
-    minute cron_interval
-    weekday '6,7'
-    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale to #{weekend_instances} --scale-available 2>&1 | logger -t info)
-    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  end
-elsif moscaler_type == 'auto'
-  cron_d 'moscaler_auto' do
-    user 'moscaler'
-    minute cron_interval
-    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale auto 2>&1 | logger -t info)
-    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  end
-
-  autoscale_config = %Q|AUTOSCALE_CONFIG="/home/moscaler/mo-scaler/autoscale.json"|
-
-  file '/home/moscaler/mo-scaler/autoscale.json' do
-    owner 'moscaler'
-    group 'moscaler'
-    content Chef::JSONCompat.to_json_pretty({
+file '/home/moscaler/mo-scaler/autoscale.json' do
+  owner 'moscaler'
+  group 'moscaler'
+  content Chef::JSONCompat.to_json_pretty({
       pause_cycles: moscaler_attributes['autoscale_pause_cycles'],
       up_increment: moscaler_attributes['autoscale_up_increment'],
       down_increment: moscaler_attributes['autoscale_down_increment'],
       strategies: moscaler_attributes['autoscale_strategies']
-    })
-  end
-
+  })
 end
 
 file '/home/moscaler/mo-scaler/.env' do
@@ -120,10 +70,11 @@ AWS_DEFAULT_REGION="#{region}"
 
 MOSCALER_MIN_WORKERS=#{moscaler_attributes['min_workers']}
 MOSCALER_IDLE_UPTIME_THRESHOLD=#{moscaler_attributes['idle_uptime_threshold']}
-#{autoscale_config}
+AUTOSCALE_CONFIG="/home/moscaler/mo-scaler/autoscale.json"
 #{loggly_config}
 |
   mode '600'
 end
 
+include_recipe "mh-opsworks-recipes::moscaler-resume"
 

--- a/recipes/moscaler-pause.rb
+++ b/recipes/moscaler-pause.rb
@@ -1,0 +1,18 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: moscaler-pause
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+[
+    'moscaler_offpeak',
+    'moscaler_normal',
+    'moscaler_weekend',
+    'moscaler_auto'
+].each do |cron_entry|
+  cron_d cron_entry do
+    action :delete
+  end
+end
+
+
+

--- a/recipes/moscaler-resume.rb
+++ b/recipes/moscaler-resume.rb
@@ -1,0 +1,59 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: moscaler-resume
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+moscaler_attributes = get_moscaler_info
+
+moscaler_type = moscaler_attributes['moscaler_type']
+debug_flag = moscaler_attributes['moscaler_debug'] ? '-d' : ''
+cron_interval = moscaler_attributes['cron_interval']
+
+if moscaler_type == 'time'
+  
+  offpeak_instances = moscaler_attributes['offpeak_instances']
+  peak_instances = moscaler_attributes['peak_instances']
+  weekend_instances = moscaler_attributes['weekend_instances']
+
+  # weekdays, offpeak, every five minutes from midnight - 7am + 11pm - midnight
+  cron_d 'moscaler_offpeak' do
+    user 'moscaler'
+    hour '0-7,23'
+    minute cron_interval
+    weekday '1-5'
+    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale to #{offpeak_instances} --scale-available 2>&1 | logger -t info)
+    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
+
+  # weekdays, normal production window, every five minutes from 8am - 11pm
+  cron_d 'moscaler_normal' do
+    user 'moscaler'
+    hour '8-22'
+    minute cron_interval
+    weekday '1-5'
+    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale to #{peak_instances} --scale-available 2>&1 | logger -t info)
+    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
+
+  # weekends, every five minutes
+  cron_d 'moscaler_weekend' do
+    user 'moscaler'
+    minute cron_interval
+    weekday '6,7'
+    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale to #{weekend_instances} --scale-available 2>&1 | logger -t info)
+    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
+
+elsif moscaler_type == 'auto'
+
+  cron_d 'moscaler_auto' do
+    user 'moscaler'
+    minute cron_interval
+    command %Q(cd /home/moscaler/mo-scaler && /usr/bin/run-one ./manager.py #{debug_flag} scale auto 2>&1 | logger -t info)
+    path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  end
+
+end
+
+
+


### PR DESCRIPTION
Separates out the part of `install-moscaler` that creates the `cron_d` entries and creates new `moscaler-pause` and `moscaler-resume` recipes that delete and create the cron jobs respectively. The `moscaler-resume` recipe gets included at the end of `install-moscaler`. The pause/resume recipes will then be executed individually by new corresponding rake tasks in [mh-opsworks](harvard-dce/mh-opsworks).