### PR TITLE
cloudwatch agent install requires python-dev package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TO BE RELEASED
 
 * Allow exit status of '255' on cloudwatch log group creation to get rid of errors due to ResourceAlreadyExistsException
+* cloudwatch logs agent install requires python-dev package
 
 ## v1.25.0 - 08/17/2017
 

--- a/recipes/install-cwlogs.rb
+++ b/recipes/install-cwlogs.rb
@@ -3,6 +3,8 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
+install_package("python-dev")
+
 region = node[:opsworks][:instance][:region]
 shared_assets_bucket = get_shared_asset_bucket_name
 


### PR DESCRIPTION
it's already listed in the mh base packages, but not all nodes run that
recipe