### PR TITLE
MI-73: Capture Agent logs to Cloudwatch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
         ./bin/rake stack:commands:execute_recipes_on_layers layers="Analytics" recipes="mh-opsworks-recipes::configure-elk-nginx-proxy"
         ./bin/rake stack:commands:execute_recipes_on_layers layers="Utility" recipes="mh-opsworks-recipes::configure-capture-agent-manager-nginx-proxy"
     
+* *REQUIRES MANUAL RECIPE RUN*
+  MI-73: recipe and script to pull capture agent logs w/ rsync, push to cloudwatch
+  
+        ./bin/rake stack:commands:execute_recipes_on_layers layers="Utility" recipes="mh-opsworks-recipes::configure-capture-agent-cwlogs"
+        
 ## v1.26.0 - 08/24/2017
 
 * Allow exit status of '255' on cloudwatch log group creation to get rid of errors due to ResourceAlreadyExistsException

--- a/files/default/rsync_ca_cwlogs.sh
+++ b/files/default/rsync_ca_cwlogs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -e
+
+# get the list of ca hosts
+ca_list=`curl -s -u $CA_STATUS_USER_PASS $CA_STATUS_URL | jq -r '.[].address'`
+ca_count=`echo $ca_list | wc -w`
+echo "Fetched $ca_count entries"
+
+# rsync the logs
+for ca_host in $ca_list; do
+    echo "fetching from $ca_host"
+    rsync -e "ssh -i $CA_KEY_FILE" -azvh --quiet --inplace \
+        --exclude "messages.*" --exclude "mhpearl.log.*" \
+        root@${ca_host}:/data/logs $CA_LOGS_BASE_DIR/$ca_host
+done
+
+# we'll only restart the agent if a new config file gets written
+restart_cwlogs_agent=0
+
+# ensure each has a cwlogs agent config file
+
+for ca_host in $ca_list; do
+
+    ca_name=`echo "$ca_host" | cut -d '.' -f 1`
+
+    mhpearl_conf_file="$LOG_AGENT_CONFIG_DIR/${ca_host}_mhpearl.conf"
+    mhpearl_log_file="$CA_LOGS_BASE_DIR/$ca_host/logs/matterhorn/mhpearl.log"
+    messages_conf_file="$LOG_AGENT_CONFIG_DIR/${ca_host}_messages.conf"
+    messages_log_file="$CA_LOGS_BASE_DIR/$ca_host/logs/messages"
+
+    if [ ! -e $mhpearl_conf_file ] && [ -e $mhpearl_log_file ]; then
+        echo "Writing conf file $mhpearl_conf_file"
+        echo "
+[${ca_name}-mhpearl]
+log_stream_name = $ca_name
+log_group_name = ${STACK_SHORTNAME}_capture-agent-mhpearl
+file = $mhpearl_log_file
+datetime_format = %Y-%m-%d %H:%M:%S,%f
+initial_position = start_of_file
+" >> $mhpearl_conf_file &&
+        restart_cwlogs_agent=1
+    fi
+
+    if [ ! -e $messages_conf_file ] && [ -e $messages_log_file ]; then
+        echo "Writing conf file $messages_conf_file"
+        echo "
+[${ca_name}-messages]
+log_stream_name = $ca_name
+log_group_name = ${STACK_SHORTNAME}_capture-agent-messages
+file = $messages_log_file
+datetime_format = %b %d %H:%M:%S
+initial_position = start_of_file
+" >> $messages_conf_file &&
+        restart_cwlogs_agent=1
+    fi
+
+done
+
+if [ $restart_cwlogs_agent -eq 1 ]; then
+    echo "Restarting cloudwatch logs agent"
+    service awslogs restart > /dev/null
+fi

--- a/metadata.rb
+++ b/metadata.rb
@@ -1019,6 +1019,18 @@ none
 * removes the moscaler cron entries
 '
 )
+recipe(
+    'mh-opsworks-recipes::configure-capture-agent-cwlogs',
+    'Installs script for rsyncing capture agent logs and configures cloudwatch logs agent to monitor them.
+
+=== attributes
+none
+
+=== effects
+* installs script for rsyncing logs and configuring cloudwatch log agent
+* creates cron entry for executing script
+'
+)
 
 depends 'nfs', '~> 2.1.0'
 depends 'apt', '~> 2.9.2'

--- a/recipes/configure-capture-agent-cwlogs.rb
+++ b/recipes/configure-capture-agent-cwlogs.rb
@@ -1,0 +1,50 @@
+# Cookbook Name:: mh-opsworks-recipes
+# Recipe:: configure-capture-agent-cwlogs
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+capture_agent_manager_info = get_capture_agent_manager_info
+stack = stack_shortname
+ca_stats_user = capture_agent_manager_info[:ca_stats_user]
+ca_stats_pass = capture_agent_manager_info[:ca_stats_passwd]
+ca_stats_url = capture_agent_manager_info[:ca_stats_json_url]
+ca_manager_user = capture_agent_manager_info[:capture_agent_manager_usr_name]
+ca_key_file = "/home/#{ca_manager_user}/.ssh/dce-epiphan"
+
+cookbook_file 'rsync_ca_cwlogs.sh' do
+  path "/usr/local/bin/rsync_ca_cwlogs.sh"
+  owner "root"
+  group "root"
+  mode "700"
+end
+
+directory '/var/log/capture_agents' do
+  owner 'root'
+  group 'root'
+  mode '755'
+end
+
+# install ssh key to capture agents
+file ca_key_file do
+  owner ca_manager_user
+  group ca_manager_user
+  content capture_agent_manager_info[:ca_private_ssh_key]
+  mode '0600'
+end
+
+cron_d 'rsync_ca_cwlogs' do
+  minute "*/2"
+  command %Q(/usr/bin/run-one /usr/local/bin/rsync_ca_cwlogs.sh 2>&1 | logger -t rsync-ca-cwlogs)
+  path '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  environment ({
+    CA_STATUS_USER_PASS: "#{ca_stats_user}:#{ca_stats_pass}",
+    CA_STATUS_URL: ca_stats_url,
+    CA_LOGS_BASE_DIR: "/var/log/capture_agents",
+    CA_KEY_FILE: ca_key_file,
+    LOG_AGENT_CONFIG_DIR: "/var/awslogs/etc/config",
+    STACK_SHORTNAME: stack
+  })
+end
+
+create_log_group(stack + "_capture-agent-messages")
+create_log_group(stack + "_capture-agent-mhpearl")


### PR DESCRIPTION
This adds a new recipe to be run on the Utility node that sets up a script for rsyncing capture agent logs from each CA device represented in the CA status json output. The script also generates configuration files for the logs to be monitored and pushed by the Cloudwatch Log Agent daemon.