### PR TITLE
MATT-2464 nginx error loglevel info for 400 bad request details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TO BE RELEASED
 
+## v1.28.0 - 10/06/2017
+
+* MATT-2464 nginx error log to INFO level for fileupload debugging
+
 ## v1.27.0 - 09/25/2017
 
 * create cloudwatch log group for utility node's squid logs

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -23,7 +23,7 @@ http {
                           '$request_time $upstream_response_time';
 
 	access_log /var/log/nginx/access.log request_time;
-	error_log /var/log/nginx/error.log;
+	error_log /var/log/nginx/error.log info;
 
 	gzip on;
 	gzip_disable "msie6";


### PR DESCRIPTION
This changes log level from default error to info to get more details about the fileupload errors.
Ref http://nginx.org/en/docs/ngx_core_module.html#error_log
