### PR TITLE
OPC-36 nginx dir create for config needs to happen before starting nginx

### DIFF
--- a/recipes/configure-nginx-proxy.rb
+++ b/recipes/configure-nginx-proxy.rb
@@ -7,6 +7,7 @@ install_package('nginx')
 
 install_nginx_logrotate_customizations
 
+# The template path variable cannot be a get, must be saved locally first
 body_temp_path = get_nginx_body_temp_path
 
 template %Q|/etc/nginx/sites-enabled/default| do
@@ -16,6 +17,15 @@ template %Q|/etc/nginx/sites-enabled/default| do
     opencast_backend_http_port: 8080,
     body_temp_path: body_temp_path
   })
+end
+
+# create path for nginx to buffer large uploads, the get can be called directly
+directory get_nginx_body_temp_path do
+  action :create
+  owner 'www-data'
+  group 'admin'
+  mode '755'
+  recursive true
 end
 
 directory '/etc/nginx/proxy-includes' do

--- a/recipes/create-opencast-directories.rb
+++ b/recipes/create-opencast-directories.rb
@@ -23,12 +23,3 @@
   end
 end
 
-# create path for nginx to buffer large uploads
-directory get_nginx_body_temp_path do
-  action :create
-  owner 'www-data'
-  group 'admin'
-  mode '755'
-  recursive true
-end
-


### PR DESCRIPTION
This pull moves the directory create for nginx temp body dir back into nginx config recipe, where it makes more sense. Also, nginx throws an error on the "service nginx reload" if that directory doesn't exist yet. 

Verified locally on a clean create:
```
INFO: Processing directory[/var/tmp/nginx/body-temp] action create (oc-opsworks-recipes::configure-nginx-proxy line 23)
INFO: directory[/var/tmp/nginx/body-temp] created directory /var/tmp/nginx/body-temp
INFO: directory[/var/tmp/nginx/body-temp] owner changed to 33
INFO: directory[/var/tmp/nginx/body-temp] mode changed to 755
INFO: Processing directory[/etc/nginx/proxy-includes] action create (oc-opsworks-recipes::configure-nginx-proxy line 31)
INFO: directory[/etc/nginx/proxy-includes] created directory /etc/nginx/proxy-includes
INFO: directory[/etc/nginx/proxy-includes] owner changed to 0
INFO: directory[/etc/nginx/proxy-includes] group changed to 0
INFO: Processing execute[service nginx reload] action run (oc-opsworks-recipes::configure-nginx-proxy line 36)
INFO: execute[service nginx reload] ran successfully
```