### PR TITLE
disable `proxy_request_buffering` on admin nginx

### DIFF
--- a/CHANGELOG-5-x.md
+++ b/CHANGELOG-5-x.md
@@ -5,6 +5,22 @@ This log is structured differently from the base `CHANGELOG.md`.
 * There is no **TO BE RELEASED** section
 * Entries should be headed with just a date; no version numbers
 
+## 07/12/2018
+
+* *REQUIRES MANUAL RECIPE RUN*
+  install latest stable nginx & disable `proxy_request_buffering` for admin nginx to allow direct streaming of uploads. 
+  For an existing cluster you can either reboot the cluster, or, if that's not desired, the various nginx recipes must be run:
+  ```bash
+    ./bin/rake stack:commands:execute_recipes_on_layers layers="Admin" recipes="oc-opsworks-recipes::configure-nginx-proxy"
+  ```
+  ```bash
+    ./bin/rake stack:commands:execute_recipes_on_layers layers="Engage" recipes="oc-opsworks-recipes::configure-engage-nginx-proxy"
+  ```
+  If you have an analytics node:
+  ```bash
+    ./bin/rake stack:commands:execute_recipes_on_layers layers="Analytics" recipes="oc-opsworks-recipes::configure-elk-nginx-proxy"
+  ```
+
 ## 07/11/2018
 
 * *REQUIRES MANUAL RECIPE RUN* *REQUIRES EDITS TO CLUSTER CONFIG*

--- a/recipes/configure-elk-nginx-proxy.rb
+++ b/recipes/configure-elk-nginx-proxy.rb
@@ -7,8 +7,8 @@ elk_info = get_elk_info
 http_auth = elk_info['http_auth']
 es_host = node[:opsworks][:instance][:private_ip]
 
-include_recipe "oc-opsworks-recipes::update-package-repo"
-install_package('nginx apache2-utils')
+include_recipe "oc-opsworks-recipes::install-nginx"
+install_package('apache2-utils')
 
 install_nginx_logrotate_customizations
 configure_nginx_cloudwatch_logs
@@ -34,9 +34,8 @@ template %Q|/etc/nginx/nginx.conf| do
   })
 end
 
-template %Q|/etc/nginx/sites-enabled/default| do
+template %Q|/etc/nginx/conf.d/default.conf| do
   source 'elk-nginx-proxy-conf.erb'
-  manage_symlink_source true
   owner 'root'
   group 'root'
   mode '644'

--- a/recipes/configure-engage-nginx-proxy.rb
+++ b/recipes/configure-engage-nginx-proxy.rb
@@ -1,19 +1,11 @@
 # Cookbook Name:: oc-opsworks-recipes
 # Recipe:: configure-engage-nginx-proxy
 
-include_recipe "oc-opsworks-recipes::update-package-repo"
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
-install_package('nginx')
+
+include_recipe "oc-opsworks-recipes::install-nginx"
 
 install_nginx_logrotate_customizations
-
-storage_info = node.fetch(
-  :storage, {
-    export_root: '/var/tmp',
-    network: '10.0.0.0/8',
-    layer_shortname: 'storage'
-  }
-)
 
 shared_storage_root = get_shared_storage_root
 
@@ -25,6 +17,10 @@ end
 
 worker_procs = get_nginx_worker_procs
 
+service 'nginx' do
+  action :nothing
+end
+
 template %Q|/etc/nginx/nginx.conf| do
   source 'nginx.conf.erb'
   variables({
@@ -32,7 +28,7 @@ template %Q|/etc/nginx/nginx.conf| do
   })
 end
 
-template %Q|/etc/nginx/sites-enabled/default| do
+template %Q|/etc/nginx/conf.d/default.conf| do
   source 'engage-nginx-proxy-conf.erb'
   manage_symlink_source true
   variables({
@@ -40,6 +36,5 @@ template %Q|/etc/nginx/sites-enabled/default| do
     opencast_backend_http_port: 8080,
     certificate_exists: certificate_exists
   })
+  notifies :restart, 'service[nginx]', :immediately
 end
-
-execute 'service nginx reload'

--- a/recipes/install-capture-agent-manager-packages.rb
+++ b/recipes/install-capture-agent-manager-packages.rb
@@ -5,6 +5,6 @@
 include_recipe "oc-opsworks-recipes::update-package-repo"
 
 install_package("python-dev python-virtualenv python-pip " \
-                "supervisor libpq-dev libffi-dev nginx redis-server")
+                "supervisor libpq-dev libffi-dev redis-server")
 
 include_recipe "oc-opsworks-recipes::clean-up-package-cache"

--- a/recipes/install-nginx.rb
+++ b/recipes/install-nginx.rb
@@ -1,0 +1,28 @@
+# Cookbook Name:: oc-opsworks-recipes
+# Recipe:: configure-nginx-proxy
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
+nginx_version = node.fetch(:nginx_version, "1.14")
+
+package 'nginx' do
+  action          :purge
+  options         "--auto-remove"
+  retries         3
+  retry_delay     5
+  ignore_failure  true
+  not_if          "dpkg -s nginx | grep -i version | grep '#{ nginx_version }[\.\-]'"
+end
+
+apt_repository 'nginx' do
+  uri           'http://nginx.org/packages/ubuntu/'
+  components    ['nginx']
+  distribution  'trusty'
+  action        :add
+  keyserver     'keyserver.ubuntu.com'
+  key           'ABF5BD827BD9BF62'
+end
+
+include_recipe "oc-opsworks-recipes::update-package-repo"
+pin_package("nginx", "#{nginx_version}.*")
+install_package('nginx')

--- a/templates/default/elk-nginx-proxy-conf.erb
+++ b/templates/default/elk-nginx-proxy-conf.erb
@@ -6,7 +6,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl default_server;
   listen [::]:443 ipv6only=on ssl;
 
   ssl_certificate     ssl/certificate.cert;
@@ -19,7 +19,7 @@ server {
 
   # Some settings are recommended by https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
   # Need SSLv3 for IE on some older windows, this is the default set.
-  # ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
 

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -46,7 +46,7 @@ server {
 
 <% if @certificate_exists %>
 server {
-  listen 443 ssl;
+  listen 443 ssl default_server;
   listen [::]:443 ipv6only=on ssl;
   directio 1M;
 
@@ -58,7 +58,7 @@ server {
 
   # Some settings are recommended by https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
   # Need SSLv3 for IE on some older windows, this is the default set.
-  # ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
 

--- a/templates/default/nginx-proxy-ssl-only.erb
+++ b/templates/default/nginx-proxy-ssl-only.erb
@@ -11,7 +11,7 @@ server {
     # some settings are recommended by
     # https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
     # Need SSLv3 for IE on some older windows, this is the default set.
-    # ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.1 TLSv1.2;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
 

--- a/templates/default/nginx-proxy.conf.erb
+++ b/templates/default/nginx-proxy.conf.erb
@@ -25,6 +25,7 @@ server {
 
   location / {
     proxy_buffering off;
+    proxy_request_buffering off;
     proxy_pass http://127.0.0.1:<%= @opencast_backend_http_port %>;
   }
 


### PR DESCRIPTION
This will allow direct streaming of uploads, bypassing the need for
temp buffers and or temp files

* install latest stable nginx from official nginx ubuntu package repo
* purges existing installation + config as config path structures have changed
* pins apt package to v1.12.*
* server configs now written to /etc/nginx/conf.d
* nginx service restart now handled the "right way"