### PR TITLE
remove geoip and useragent parsing from logstash config 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * 'yajl-ruby' gem version update to address security vulnerability
 * added `buildspec.yml` file to allow automated CodeBuild builds. See the `harvard-dce/mh-opsworks-builder` project.
+* updated logstash config: remove geoip and useragent parsing (now performed by harvester)
 
 ## v1.29.0 - 10/26/2017
 

--- a/templates/default/logstash.conf.erb
+++ b/templates/default/logstash.conf.erb
@@ -22,25 +22,6 @@ filter {
     match => [ "timestamp", "YYYY-MM-dd'T'HH:mm:ssZZ" ]
     remove_field => ["timestamp"]
   }
-  mutate {
-    add_field => {
-      "hostname" => "%{ip}"
-    }
-  }
-  geoip {
-    source => "ip"
-    lru_cache_size => 100000
-  }
-  if [useragent] =~ /.+/ {
-    useragent {
-      lru_cache_size => 100000
-      source => "useragent"
-      target => "ua"
-    }
-  }
-  mutate {
-    remove_field => "useragent"
-  }
 }
 
 output {


### PR DESCRIPTION
This functionality will now be performed by the harvester, release v1.3.0, which will be released concurrently.