### PR TITLE
OPC MATT-2406 nodes that do not dispatch should not perform hearbeats

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -700,7 +700,7 @@ module MhOpsworksRecipes
     end
 
     # nodes that don't dispatch should also not do hearbeat service health checks
-    def set_service_registry_dispatch_interval(current_deploy_root)
+    def set_service_registry_intervals(current_deploy_root)
       template %Q|#{current_deploy_root}/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg| do
         source 'org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg.erb'
         owner 'opencast'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -699,13 +699,15 @@ module MhOpsworksRecipes
       end
     end
 
+    # nodes that don't dispatch should also not do hearbeat service health checks
     def set_service_registry_dispatch_interval(current_deploy_root)
       template %Q|#{current_deploy_root}/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg| do
         source 'org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg.erb'
         owner 'opencast'
         group 'opencast'
         variables({
-          dispatch_interval: 0
+          dispatch_interval: 0,
+          heartbeat_interval: 0
         })
       end
     end

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -112,7 +112,7 @@ deploy_revision "opencast" do
     )
 
     # ENGAGE SPECIFIC
-    set_service_registry_dispatch_interval(most_recent_deploy)
+    set_service_registry_intervals(most_recent_deploy)
 #    configure_usertracking(most_recent_deploy, user_tracking_authhost)
     install_otherpubs_service_config(most_recent_deploy, opencast_repo_root, auth_host)
     install_otherpubs_service_series_impl_config(most_recent_deploy)

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -92,7 +92,7 @@ deploy_revision "opencast" do
     )
 
     # WORKER SPECIFIC
-    set_service_registry_dispatch_interval(most_recent_deploy)
+    set_service_registry_intervals(most_recent_deploy)
     # /WORKER SPECIFIC
 
     template %Q|#{most_recent_deploy}/etc/custom.properties| do

--- a/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
+++ b/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
@@ -390,6 +390,10 @@ prop.admin.shortcut.player.volume_up=+
 prop.admin.shortcut.player.volume_down=-
 prop.admin.shortcut.player.mute=m
 
+## DCE t/OPC-155
+prop.admin.shortcut.player.previous_second=j
+prop.admin.shortcut.player.next_second=l
+
 # Shortcut definitions for admin UI video editor
 # Format: prop.admin.shortcut.editor.<action>=<key>
 prop.admin.shortcut.editor.split_at_current_time=v

--- a/templates/default/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg.erb
+++ b/templates/default/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg.erb
@@ -11,6 +11,7 @@ dispatchinterval=<%= @dispatch_interval %>
 # The interval in seconds between checking if the hosts in the service registry hosts are still alive. The default value 
 # is 60 seconds. Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
 #heartbeat.interval=0
+heartbeat.interval=<%= @heartbeat_interval %>
 
 # Whether to collect detailed job statistics information.  This can cause excessive database load (see MH-10034).
 jobstats.collect=false


### PR DESCRIPTION
To reduce unnecessary internode ping flurry.