### PR TITLE
OPC MATT-2406 nodes that do not dispatch should not perform service check

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -703,13 +703,15 @@ module MhOpsworksRecipes
       end
     end
 
+    # nodes that don't dispatch should also not do hearbeat service health checks
     def set_service_registry_dispatch_interval(current_deploy_root)
       template %Q|#{current_deploy_root}/etc/services/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.properties| do
         source 'ServiceRegistryJpaImpl.properties.erb'
         owner 'matterhorn'
         group 'matterhorn'
         variables({
-          dispatch_interval: 0
+          dispatch_interval: 0,
+          heartbeat_interval: 0
         })
       end
     end

--- a/templates/default/ServiceRegistryJpaImpl.properties.erb
+++ b/templates/default/ServiceRegistryJpaImpl.properties.erb
@@ -11,6 +11,7 @@ dispatchinterval=<%= @dispatch_interval %>
 # The interval in seconds between checking if the hosts in the service registry hosts are still alive. The default value 
 # is 60 seconds. Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
 #heartbeat.interval=0
+heartbeat.interval=<%= @heartbeat_interval %>
 
 # Whether to collect detailed job statistics information.  This can cause excessive database load (see MH-10034).
 jobstats.collect=false


### PR DESCRIPTION
Only the admin node needs to perform intra-node service checks since it also does the dispatching