### PR TITLE
OPC-66-users-groups Changes for allowing producer users and ldap supp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* LDAP integration (OPC-66).
+
 * 'yajl-ruby' gem version update to address security vulnerability
 * added `buildspec.yml` file to allow automated CodeBuild builds. See the `harvard-dce/mh-opsworks-builder` project.
 * pinned 'mixlib-archive' gem to previous version because of broken release

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -238,6 +238,17 @@ module MhOpsworksRecipes
       )
     end
 
+    def get_ldap_conf
+      node.fetch(
+        :ldap_conf, {
+          enabled: false,
+          url: '',
+          userdn: '',
+          pass: ''
+        }
+      )
+    end
+
     def get_ibm_watson_transcript_bucket_name
       node[:ibm_watson_transcript_sync_bucket_name]
     end
@@ -872,6 +883,7 @@ module MhOpsworksRecipes
 
     def install_default_tenant_config(current_deploy_root, public_dns_name, private_dns_name)
       lti_oauth_info = get_lti_auth_info
+      ldap_conf = get_ldap_conf
       template %Q|#{current_deploy_root}/etc/security/mh_default_org.xml| do
         source 'mh_default_org.xml.erb'
         owner 'opencast'
@@ -879,7 +891,8 @@ module MhOpsworksRecipes
         variables({
           lti_oauth: lti_oauth_info,
           unproxied_name: public_dns_name,
-          proxy_name: public_dns_name
+          proxy_name: public_dns_name,
+          ldap_conf: ldap_conf
         })
       end
     end
@@ -889,6 +902,17 @@ module MhOpsworksRecipes
         {
           consumer: 'consumerkey',
           secret: 'sharedsecret'
+        }
+      )
+    end
+
+    def get_ldap_conf
+      node.fetch(
+        :ldap_conf, {
+          enabled: false,
+          url: '',
+          userdn: '',
+          pass: ''
         }
       )
     end
@@ -955,6 +979,19 @@ module MhOpsworksRecipes
           live_stream_name: live_stream_name,
           live_streaming_url: live_streaming_url,
           distribution: distribution 
+        })
+      end
+    end
+
+    def install_ldap_config(current_deploy_root, ldap_url, ldap_userdn, ldap_psw)
+      template %Q|#{current_deploy_root}/etc/org.opencastproject.userdirectory.ldap-dce.cfg| do
+        source 'org.opencastproject.userdirectory.ldap-dce.cfg.erb'
+        owner 'opencast'
+        group 'opencast'
+        variables({
+          ldap_url: ldap_url,
+          ldap_userdn: ldap_userdn,
+          ldap_psw: ldap_psw 
         })
       end
     end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -41,6 +41,13 @@ live_streaming_url = get_live_streaming_url
 live_stream_name = get_live_stream_name
 distribution = using_local_distribution ? 'download' : 'aws.s3'
 
+# LDAP credentials
+ldap_conf = get_ldap_conf
+ldap_enabled = ldap_conf[:enabled]
+ldap_url = ldap_conf[:url]
+ldap_userdn = ldap_conf[:userdn]
+ldap_psw = ldap_conf[:pass]
+
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_activated = node.fetch(:auth_activated, 'true')
@@ -107,6 +114,9 @@ deploy_revision "opencast" do
 #      most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
 #    )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name, live_streaming_url, distribution)
+    if ldap_enabled
+      install_ldap_config(most_recent_deploy, ldap_url, ldap_userdn, ldap_psw)
+    end
 #    # Admin Specific
     install_otherpubs_service_config(most_recent_deploy, opencast_repo_root, auth_host)
     install_otherpubs_service_series_impl_config(most_recent_deploy)

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -53,6 +53,13 @@ live_streaming_url = get_live_streaming_url
 live_stream_name = get_live_stream_name
 distribution = using_local_distribution ? 'download' : 'aws.s3'
 
+# LDAP credentials
+ldap_conf = get_ldap_conf
+ldap_enabled = ldap_conf[:enabled]
+ldap_url = ldap_conf[:url]
+ldap_userdn = ldap_conf[:userdn]
+ldap_psw = ldap_conf[:pass]
+
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_activated = node.fetch(:auth_activated, 'true')
@@ -119,6 +126,9 @@ deploy_revision "opencast" do
       most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name, live_streaming_url, distribution)
+    if ldap_enabled
+      install_ldap_config(most_recent_deploy, ldap_url, ldap_userdn, ldap_psw)
+    end
     install_otherpubs_service_config(most_recent_deploy, opencast_repo_root, auth_host)
     install_otherpubs_service_series_impl_config(most_recent_deploy)
 #    install_aws_s3_file_archive_service_config(most_recent_deploy, region, s3_file_archive_bucket_name)

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -24,6 +24,13 @@ capture_agent_monitor_url = node.fetch(
   :capture_agent_monitor_url, 'http://example.com/monitor_url'
 )
 
+# LDAP credentials
+ldap_conf = get_ldap_conf
+ldap_enabled = ldap_conf[:enabled]
+ldap_url = ldap_conf[:url]
+ldap_userdn = ldap_conf[:userdn]
+ldap_psw = ldap_conf[:pass]
+
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_activated = node.fetch(:auth_activated, 'true')
@@ -95,6 +102,12 @@ deploy_revision "opencast" do
     install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
 #    remove_felix_fileinstall(most_recent_deploy)
 #    install_smtp_config(most_recent_deploy)
+
+    if ldap_enabled
+      install_ldap_config(most_recent_deploy, ldap_url, ldap_userdn, ldap_psw)
+    end
+
+    install_ldap_config(most_recent_deploy, ldap_url, ldap_userdn, ldap_psw)
     install_default_tenant_config(most_recent_deploy, public_engage_hostname, private_hostname)
     install_auth_service(
       most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -20,6 +20,13 @@ capture_agent_monitor_url = node.fetch(
   :capture_agent_monitor_url, 'http://example.com/monitor_url'
 )
 
+# LDAP credentials
+ldap_conf = get_ldap_conf
+ldap_enabled = ldap_conf[:enabled]
+ldap_url = ldap_conf[:url]
+ldap_userdn = ldap_conf[:userdn]
+ldap_psw = ldap_conf[:pass]
+
 auth_host = node.fetch(:auth_host, 'example.com')
 auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com/some/url')
 auth_key = node.fetch(:auth_key, '')
@@ -79,6 +86,9 @@ deploy_revision "opencast" do
     install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
 #    remove_felix_fileinstall(most_recent_deploy)
 #    install_smtp_config(most_recent_deploy)
+    if ldap_enabled
+      install_ldap_config(most_recent_deploy, ldap_url, ldap_userdn, ldap_psw)
+    end
     install_auth_service(
       most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )

--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -28,6 +28,7 @@
     <!-- ################ -->
 
     <!-- Allow anonymous access to the login form -->
+    <sec:intercept-url pattern="/" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/admin-ng/login.html" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/sysinfo/bundles/version" method="GET" access="ROLE_ANONYMOUS" />
 
@@ -105,6 +106,8 @@
     <sec:intercept-url pattern="/admin-ng/event/*/metadata" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_METADATA_EDIT" />
     <sec:intercept-url pattern="/admin-ng/event/*/scheduling" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT" />
     <sec:intercept-url pattern="/admin-ng/event/*/workflows" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT" />
+    <sec:intercept-url pattern="/admin-ng/event/*/workflows/*/action/retry" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT" />
+    <sec:intercept-url pattern="/admin-ng/event/*/workflows/*/action/none" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT" />
     <sec:intercept-url pattern="/admin-ng/event/*/comment/*/*" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_COMMENTS_EDIT" />
     <sec:intercept-url pattern="/admin-ng/event/*/comment/*" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_COMMENTS_EDIT"/>
     <sec:intercept-url pattern="/admin-ng/event/*/optout/*" method="PUT" access="ROLE_ADMIN, ROLE_UI_EVENTS_STATUS_EDIT" />
@@ -154,6 +157,10 @@
     <sec:intercept-url pattern="/admin-ng/themes/*" method="DELETE" access="ROLE_ADMIN, ROLE_UI_THEMES_DELETE" />
     <sec:intercept-url pattern="/admin-ng/users/*" method="DELETE" access="ROLE_ADMIN, ROLE_UI_USERS_DELETE" />
 
+    <!-- #DCE Repub -->
+    <sec:intercept-url pattern="/repubapp/**" method="GET" access="ROLE_ADMIN, ROLE_DCE_REPUB" />
+    <sec:intercept-url pattern="/repub/**" method="POST" access="ROLE_ADMIN, ROLE_DCE_REPUB" />
+ 
     <!-- Securing the URLs for the external API interface -->
     <!-- External API GET Endpoints -->
     <sec:intercept-url pattern="/api" method="GET" access="ROLE_ADMIN, ROLE_API"/>
@@ -240,9 +247,12 @@
 
     <!-- #DCE OPC-54-test-local uses this link from the admin ui, which is a 
 	 redirect to Paella. This should come before /engage/** because the order matters! -->
-    <sec:intercept-url pattern="/engage/player/watchAdminRedirect.html" method="GET" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/engage/player/watchAdminRedirect.html" method="GET" access="ROLE_ADMIN, ROLE_DCE_TEST_LOCAL" />
     <!-- #DCE KHD: MATT-2231 require login for annots summary (extra data auth on oauth performed in endpoint) -->
-    <sec:intercept-url pattern="/engage/ui/annots/**" access="ROLE_ADMIN, ROLE_OAUTH_USER" />
+    <sec:intercept-url pattern="/engage/ui/annots/**" access="ROLE_ADMIN, ROLE_OAUTH_USER, ROLE_DCE_OC_SOCIAL_ADMIN" />
+    <!-- Enable anonymous access to the engage player and the GET endpoints it requires -->
+    <sec:intercept-url pattern="/engage/ui/**" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/engage/**" access="ROLE_ANONYMOUS" />
     <!-- #DCE KHD: Alt paths: DCE former paella player, prep theodulpass -->
     <sec:intercept-url pattern="/theodulpass/ui/**" method="GET" access="ROLE_ANONYMOUS" />
     <!-- #DCE KHD: MATT-1569 endpoint for Legacy pub data -->
@@ -250,9 +260,6 @@
     <!-- Default Matterhorn engage player module loads at engage-player -->
     <!--  #DCE -->
 
-   <!-- Enable anonymous access to the engage player and the GET endpoints it requires -->
-    <sec:intercept-url pattern="/engage/ui/**" access="ROLE_ANONYMOUS" />
-    <sec:intercept-url pattern="/engage/**" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/engage-player/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/search/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/usertracking/**" method="GET" access="ROLE_ANONYMOUS" />
@@ -274,14 +281,14 @@
     <sec:intercept-url pattern="/annotation/property*" method="POST" access="ROLE_ANONYMOUS" />
     <!-- MATT-2245 (end) -->
     <!-- Read specific annotation, role admin and oauth user (extra auth on oauth performed in endpoint) -->
-    <sec:intercept-url pattern="/annotation/**" method="GET" access="ROLE_ADMIN, ROLE_OAUTH_USER" />
+    <sec:intercept-url pattern="/annotation/**" method="GET" access="ROLE_ADMIN, ROLE_DCE_OC_SOCIAL_ADMIN, ROLE_OAUTH_USER" />
     <!-- Adding annotation, security is done in REST endpoint -->
     <sec:intercept-url pattern="/annotation/" method="PUT" access="ROLE_ANONYMOUS" />
     <!-- Updating annotation, role admin only -->
-    <sec:intercept-url pattern="/annotation/**" method="PUT" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/annotation/**" method="PUT" access="ROLE_ADMIN, ROLE_DCE_OC_SOCIAL_ADMIN" />
     <!-- Deleting annotation, role admin only -->
-    <sec:intercept-url pattern="/annotation/**" method="DELETE" access="ROLE_ADMIN" />
- 
+    <sec:intercept-url pattern="/annotation/**" method="DELETE" access="ROLE_ADMIN, ROLE_DCE_OC_SOCIAL_ADMIN" />
+
     <!-- Enable anonymous access to the OAI-PMH repository              -->
     <!-- The OAI-PMH specification demands boths GET and POST requests  -->
     <!-- Please make sure that the path configured here matches         -->
@@ -517,7 +524,63 @@
       </bean>
     </property>
   </bean>  
-  
+
+<%# ----------------------------------------- %>
+<%# This is only included if ldap is enabled. %>
+<%# ----------------------------------------- %>
+<% if @ldap_conf[:enabled] %>
+
+  <!-- ################ -->
+  <!-- # LDAP Support # -->
+  <!-- ################ -->
+
+  <bean id="contextSource"
+    class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
+    <!-- URL of the LDAP server -->
+    <constructor-arg value="<%= @ldap_conf[:url] %>" />
+    <!-- "Distinguished name" for the unprivileged user -->
+    <!-- This user is merely to perform searches in the LDAP to find the users to login -->
+    <property name="userDn" value="<%= @ldap_conf[:userdn] %>" />
+    <!-- Password of the user above -->
+    <property name="password" value="<%= @ldap_conf[:pass] %>" />
+  </bean>
+
+  <bean id="ldapAuthProvider"
+    class="org.springframework.security.ldap.authentication.LdapAuthenticationProvider">
+    <constructor-arg>
+      <bean
+        class="org.springframework.security.ldap.authentication.BindAuthenticator">
+        <constructor-arg ref="contextSource" />
+        <property name="userDnPatterns">
+          <list>
+            <!-- Dn patterns to search for valid users. Multiple "<value>" tags are allowed -->
+            <!-- value>uid={0},ou=Group,dc=my-institution,dc=country</value -->
+            <value>uid={0},ou=people,dc=dce,dc=harvard,dc=edu</value>
+          </list>
+        </property>
+        <!-- If your user IDs are not part of the user Dn's, you can use a search filter to find them -->
+        <!-- This property can be used together with the "userDnPatterns" above -->
+        <!--
+        <property name="userSearch">
+          <bean name="filterUserSearch" class="org.springframework.security.ldap.search.FilterBasedLdapUserSearch">
+            < ! - - Base Dn from where the users will be searched for - - >
+            <constructor-arg index="0" value="ou=group,dc=dce,dc=harvard,dc=edu" />
+            < ! - - Filter to located valid users. Use {0} as a placeholder for the login name - - >
+            <constructor-arg index="1" value="(memberUid={0})" />
+            <constructor-arg ref="contextSource" />
+          </bean>
+        </property>
+        -->
+      </bean>
+    </constructor-arg>
+
+    <!-- Defines how the user attributes are converted to authorities (roles) -->
+    <constructor-arg ref="authoritiesPopulator" />
+  </bean>
+
+<% end %>
+<%# ----------------------------------------- %>
+
   <!-- ###################### -->
   <!-- # Shibboleth Support # -->
   <!-- ###################### -->
@@ -570,6 +633,17 @@
   <osgi:reference id="userDirectoryService" cardinality="1..1"
                   interface="org.opencastproject.security.api.UserDirectoryService" />
 
+<%# ----------------------------------------- %>
+<%# This is only included if ldap is enabled. %>
+<%# ----------------------------------------- %>
+<% if @ldap_conf[:enabled] %>
+
+  <osgi:reference id="authoritiesPopulator" cardinality="1..1"
+                  interface="org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator"
+                  filter="(instanceId=dce)" />
+
+<% end %>
+<%# ----------------------------------------- %>
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->
@@ -582,6 +656,13 @@
     <sec:authentication-provider user-service-ref="userDetailsService">
       <sec:password-encoder hash="md5"><sec:salt-source user-property="username" /></sec:password-encoder>
     </sec:authentication-provider>
+<%# ----------------------------------------- %>
+<%# This is only included if ldap is enabled. %>
+<%# ----------------------------------------- %>
+<% if @ldap_conf[:enabled] %>
+    <sec:authentication-provider ref="ldapAuthProvider" />
+<% end %>
+<%# ----------------------------------------- %>
   </sec:authentication-manager>
 
   <!-- Do not use a request cache -->

--- a/templates/default/org.opencastproject.userdirectory.ldap-dce.cfg.erb
+++ b/templates/default/org.opencastproject.userdirectory.ldap-dce.cfg.erb
@@ -1,0 +1,72 @@
+## A unique identifier for this connection. It only has effect within Opencast.
+## May be different as the <ID> used above, but this is not recommended for clarity
+## IMPORTANT: This identifier must be the same as the one used in the security.xml
+## file to get a reference to an 'authoritiesPopulator'
+org.opencastproject.userdirectory.ldap.id=dce
+
+## The URL to the LDAP server
+## Example: ldap://ldap.berkeley.edu
+org.opencastproject.userdirectory.ldap.url=<%= @ldap_url %>
+
+## The user and password used for LDAP authentication.  If left commented, the LDAP provider will use an anonymous bind.
+org.opencastproject.userdirectory.ldap.userDn=<%= @ldap_userdn %>
+org.opencastproject.userdirectory.ldap.password=<%= @ldap_psw %>
+
+## The base path within LDAP to search for users
+## Example: ou=people,dc=berkeley,dc=edu
+org.opencastproject.userdirectory.ldap.searchbase=dc=dce,dc=harvard,dc=edu
+
+## The search filter to use for identifying users by ID
+org.opencastproject.userdirectory.ldap.searchfilter=(uid={0})
+
+## The maximum number of users to cache
+org.opencastproject.userdirectory.ldap.cache.size=1000
+
+## The maximum number of minutes to cache a user
+org.opencastproject.userdirectory.ldap.cache.expiration=5
+
+## The comma-separated list of attributes that will be translated into roles.
+## Note that the attributes will be converted to uppercase and that they may be prefixed with a string, as defined in the
+## configuration below. Please refer to the documentation of the "roleprefix" property below.
+## Example: berkeleyEduAffiliations,departmentNumber
+org.opencastproject.userdirectory.ldap.roleattributes=
+
+## The organization for this provider
+org.opencastproject.userdirectory.ldap.org=mh_default_org
+
+## A prefix to be added to the roles read by this provider. It defaults to an empty string "", i.e. no prefix added.
+## Please note that this property had previous a default value of "ROLE_", which is still recommended, but not mandatory.
+##
+## The prefix is *NOT* added to a role if any of the following conditions is met:
+##
+##   * The role starts with any of the prefixes defined in the parameter 'exclude.prefixes'
+##   * The role was not actually read from the provider, but defined in the 'extra.roles' list below
+org.opencastproject.userdirectory.ldap.roleprefix=ROLE_GROUP_DCE_
+
+## A comma-separated list of prefixes. When the roles read from LDAP start with any of these, then the prefix defined
+## above is not prepended to the role.
+## Please note that if the "uppercase" parameter was provided, these prefixes are converted accordingly
+org.opencastproject.userdirectory.ldap.exclude.prefixes=
+
+## Whether or not the role names should be converted to uppercase. It defaults to "true".
+## Please note that this setting affects the prefix defined above.
+org.opencastproject.userdirectory.ldap.uppercase=true
+
+## A comma-separated list of extra roles to apply to all the users authenticated with this LDAP instance
+## The roles in this list are converted to uppercase if the corresponding parameter is set. However, the 'roleprefix'
+## setting does not affect them -i.e. they will not be further modified even if 'roleprefix' is set.
+org.opencastproject.userdirectory.ldap.extra.roles=ROLE_ANONYMOUS,ROLE_USER
+
+#####################
+### #DCE specific ###
+#####################
+
+## Base from where to search groups
+org.opencastproject.userdirectory.ldap.groupsearchbase=ou=Group,dc=dce,dc=harvard,dc=edu
+
+## Filter to search which groups the user belongs to
+org.opencastproject.userdirectory.ldap.groupsearchfilter=(memberUid={1})
+
+## Attribute that contains the user email
+org.opencastproject.userdirectory.ldap.useremail=mail
+


### PR DESCRIPTION
…ort.

Added new roles to endpoints: repub, resume/abort paused wf, watch redirect (test-local), oc social admin.
Adding ldap config, conditional to 'enabled' flag. Local vagrant has no ldap by default.