### PR TITLE
fixing implementation of newrelic enabling logic

### DIFF
--- a/CHANGELOG-5-x.md
+++ b/CHANGELOG-5-x.md
@@ -5,6 +5,10 @@ This log is structured differently from the base `CHANGELOG.md`.
 * There is no **TO BE RELEASED** section
 * Entries should be headed with just a date; no version numbers
 
+## 07/23/2018
+
+* fixing the enabling logic for the earlier newrelic changes
+
 ## 07/18/2018
 
 * only run the squid install recipe if external storage (i.e. zadara) is being used

--- a/recipes/install-newrelic.rb
+++ b/recipes/install-newrelic.rb
@@ -9,7 +9,7 @@
 layer_name = layer_name_from_hostname
 
 return unless newrelic_config
-return unless enable_newrelic_layer?(layer_name)
+return unless enable_newrelic_for_layer?(layer_name)
 
 # config template values
 license_key = newrelic_config[layer_name.to_s][:key]

--- a/templates/default/opencast-setenv.erb
+++ b/templates/default/opencast-setenv.erb
@@ -42,6 +42,8 @@ NEWRELIC="-javaagent:${NEWRELIC_JAR} $NEWRELIC_CONFIG"
 NEWRELIC=""
 <% end %>
 
+LOGDIR=<%= @opencast_log_directory %>
+
 GC="-Xloggc:${LOGDIR}/gcnormal.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
 GC="${GC} -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintHeapAtGC"
 GC="${GC} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=20 -XX:GCLogFileSize=32M -XX:+UseG1GC"


### PR DESCRIPTION
This is a fix for V99hl33QwzQp which didn't handle enabling/not enabling newrelic properly for nodes not defined in the cluster config's newrelic block. Also the garbage collection log was getting written to the wrong place.