### PR TITLE
t/MI-106: improvements to activemq installation/logging

### DIFF
--- a/CHANGELOG-5-x.md
+++ b/CHANGELOG-5-x.md
@@ -5,6 +5,10 @@ This log is structured differently from the base `CHANGELOG.md`.
 * There is no **TO BE RELEASED** section
 * Entries should be headed with just a date; no version numbers
 
+## 09/10/2018
+
+* MI-106: improvements to activemq install
+
 ## 09/07/2018
 
 * enable activemq install for all-in-one local clusters

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,8 @@ default['maven']['mavenrc']['opts'] = '-Dmaven.repo.local=/root/.m2/repository -
 # ActiveMQ
 default['activemq']['install_java'] = false
 default['activemq']['version'] = '5.15.4'
+default['activemq']['transport_protocols'] = 'TLSv1.1,TLSv1.2'
+default['activemq']['home'] = '/opt/opencast/activemq'
 # this is only to tell the 3rd-party activemq recipe not to issue its own
 # service restart; we do that ourselves in the configure-activemq recipe
 default['activemq']['enabled'] = false

--- a/files/default/activemq-log4j.properties
+++ b/files/default/activemq-log4j.properties
@@ -1,0 +1,78 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# This file controls most of the logging in ActiveMQ which is mainly based around
+# the commons logging API.
+#
+log4j.rootLogger=INFO, console, logfile
+log4j.logger.org.apache.activemq.spring=WARN
+log4j.logger.org.apache.activemq.web.handler=WARN
+log4j.logger.org.springframework=WARN
+log4j.logger.org.apache.xbean=WARN
+log4j.logger.org.apache.camel=INFO
+log4j.logger.org.eclipse.jetty=WARN
+
+# When debugging or reporting problems to the ActiveMQ team,
+# comment out the above lines and uncomment the next.
+
+#log4j.rootLogger=DEBUG, logfile, console
+
+# Or for more fine grained debug logging uncomment one of these
+#log4j.logger.org.apache.activemq=DEBUG
+#log4j.logger.org.apache.camel=DEBUG
+
+# Console appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%5p | %m%n
+log4j.appender.console.threshold=INFO
+
+# File appender
+log4j.appender.logfile=org.apache.log4j.RollingFileAppender
+log4j.appender.logfile.file=${activemq.data}/activemq.log
+log4j.appender.logfile.maxFileSize=10240KB
+log4j.appender.logfile.maxBackupIndex=30
+log4j.appender.logfile.append=true
+log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
+log4j.appender.logfile.layout.ConversionPattern=%d | %-5p | %m | %c | %t%n
+# use some of the following patterns to see MDC logging data
+#
+# %X{activemq.broker}
+# %X{activemq.connector}
+# %X{activemq.destination}
+#
+# e.g.
+#
+# log4j.appender.logfile.layout.ConversionPattern=%d | %-20.20X{activemq.connector} | %-5p | %m | %c | %t%n
+
+log4j.throwableRenderer=org.apache.log4j.EnhancedThrowableRenderer
+
+###########
+# Audit log
+###########
+
+log4j.additivity.org.apache.activemq.audit=false
+log4j.logger.org.apache.activemq.audit=INFO, audit
+
+log4j.appender.audit=org.apache.log4j.RollingFileAppender
+log4j.appender.audit.file=${activemq.data}/audit.log
+log4j.appender.audit.maxFileSize=1024KB
+log4j.appender.audit.maxBackupIndex=5
+log4j.appender.audit.append=true
+log4j.appender.audit.layout=org.apache.log4j.PatternLayout
+log4j.appender.audit.layout.ConversionPattern=%-5p | %m | %t%n

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -777,13 +777,16 @@ module MhOpsworksRecipes
       end
     end
 
+    def total_ram_in_meg
+      ram_finder = Mixlib::ShellOut.new(%q(grep MemTotal /proc/meminfo | sed -r 's/[^0-9]//g'))
+      ram_finder.run_command
+      ram_finder.error!
+      ram_finder.stdout.chomp.to_i / 1024
+    end
+
     def xmx_ram_for_this_node(xmx_ram_ratio)
       auto_configure_java_xmx_memory = node.fetch(:auto_configure_java_xmx_memory, true)
       if auto_configure_java_xmx_memory
-        ram_finder = Mixlib::ShellOut.new(%q(grep MemTotal /proc/meminfo | sed -r 's/[^0-9]//g'))
-        ram_finder.run_command
-        ram_finder.error!
-        total_ram_in_meg = ram_finder.stdout.chomp.to_i / 1024
         # configure Xmx value as a percent of the total ram for this
         # node, with a minimum of 4096
         [(total_ram_in_meg * xmx_ram_ratio).to_i, 4096].max

--- a/recipes/configure-activemq.rb
+++ b/recipes/configure-activemq.rb
@@ -3,12 +3,35 @@
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
+# for getting available ram to determine max_memory value
+::Chef::Recipe.send(:include, MhOpsworksRecipes::DeployHelpers)
+
 activemq_bind_host = node[:opsworks][:instance][:private_dns_name]
 activemq_version = node.default['activemq']['version']
-activemq_config = %Q|/opt/apache-activemq-#{activemq_version}/conf/activemq.xml|
+activemq_base = %Q|#{node['activemq']['home']}/apache-activemq-#{activemq_version}|
+activemq_wrapper_conf = %Q|#{activemq_base}/bin/linux/wrapper.conf|
+
+cookbook_file 'activemq-log4j.properties' do
+  path %Q|#{activemq_base}/conf/log4j.properties|
+  owner "root"
+  group "root"
+  mode "644"
+end
+
+increase_max_memory = total_ram_in_meg > 16000
+
+# for bigger instances (i.e. prod clusters) bump the max memory to 2G
+ruby_block "max_memory" do
+  block do
+    sed = Chef::Util::FileEdit.new(activemq_wrapper_conf)
+    sed.search_file_replace(/^(wrapper\.java\.maxmemory)=\d+/, '\1=2048')
+    sed.write_file
+  end
+  only_if { increase_max_memory }
+end
 
 template 'activemq_config' do
-  path activemq_config
+  path %Q|#{activemq_base}/conf/activemq.xml|
   source 'activemq.xml.erb'
   mode '0755'
   owner 'root'
@@ -22,5 +45,8 @@ service 'activemq' do
   supports start: true, stop: true, restart: true, status: true
   action [:enable, :start]
   subscribes :restart, "template[activemq_config]", :immediately
+  subscribes :restart, "ruby_block[max_memory]", :immediately
 end
 
+activemq_log = "#{activemq_base}/data/activemq.log"
+configure_cloudwatch_log('activemq', activemq_log, "%Y-%m-%d %H:%M:%S")

--- a/recipes/install-oc-base-packages.rb
+++ b/recipes/install-oc-base-packages.rb
@@ -2,6 +2,7 @@
 # Recipe:: install-oc-base-packages
 
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+
 include_recipe "oc-opsworks-recipes::update-package-repo"
 
 packages = %Q|autofs5 curl dkms gzip jq libglib2.0-dev mysql-client postfix python-pip python-dev rsyslog-gnutls run-one tesseract-ocr|


### PR DESCRIPTION
Changes:
* installs under the /opt/opencast volume (vs root volume) for persistence and increased storage capacity
* specify only TLSv1.1/2 protocols as TLSv1.0 is insecure/deprecated
* I left the log4j config mostly alone but increased the max file size to 10mb + keep 30 (up from 1mb + keep 5), a 60x increase in retention
* bump the -Xmx to 2048 for instances w/ > 16G of ram
* send activemq.log to cloudwatch