### PR TITLE
OPC-149 config to allow 1x combo pub list to pull from 5x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* OPC-149 Otherpubs config to combine Opencast pubs on pub listing
+
 ## v1.33.0 - 10/15/2018
 
 * MI-114: cloudwatch metric for number of online workers

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -676,7 +676,7 @@ module MhOpsworksRecipes
       end
     end
 
-    def install_otherpubs_service_config(current_deploy_root, matterhorn_repo_root, auth_host)
+    def install_otherpubs_service_config(current_deploy_root, matterhorn_repo_root, auth_host, other_oc_host, other_oc_prefother_series, other_oc_preflocal_series)
       download_episode_defaults_json_file(current_deploy_root)
 
       template %Q|#{current_deploy_root}/etc/services/edu.harvard.dce.otherpubs.service.OtherpubsService.properties| do
@@ -685,6 +685,9 @@ module MhOpsworksRecipes
         group 'matterhorn'
         variables({
           auth_host: auth_host,
+          other_oc_host: other_oc_host,
+          other_oc_prefother_series: other_oc_prefother_series,
+          other_oc_preflocal_series: other_oc_preflocal_series,
           matterhorn_repo_root: matterhorn_repo_root
         })
       end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -45,6 +45,15 @@ auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com
 auth_activated = node.fetch(:auth_activated, 'true')
 auth_key = node.fetch(:auth_key, '')
 
+# OPC-149 other oc host for pub list merge
+# The ignore-flag default value signals the config consumer
+# That the value for the config was not intentionally set and should
+# be ignored.
+ignore_flag = 'IGNORE_ME'
+other_oc_host = node.fetch(:other_oc_host, ignore_flag)
+other_oc_prefother_series = node.fetch(:other_oc_prefother_series, ignore_flag)
+other_oc_preflocal_series = node.fetch(:other_oc_preflocal_series, ignore_flag)
+
 git_data = node[:deploy][:matterhorn][:scm]
 
 public_engage_hostname = get_public_engage_hostname
@@ -103,7 +112,7 @@ deploy_revision "matterhorn" do
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
     # Admin Specific
-    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
+    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host, other_oc_host, other_oc_prefother_series, other_oc_preflocal_series)
     install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_aws_s3_file_archive_service_config(most_recent_deploy, region, s3_file_archive_bucket_name)
     install_ibm_watson_transcription_service_config(most_recent_deploy, ibm_watson_username, ibm_watson_psw)

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -50,6 +50,15 @@ auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com
 auth_activated = node.fetch(:auth_activated, 'true')
 auth_key = node.fetch(:auth_key, '')
 
+# OPC-149 other oc host for pub list merge
+# The ignore-flag default value signals the config consumer
+# That the value for the config was not intentionally set and should
+# be ignored.
+ignore_flag = 'IGNORE_ME'
+other_oc_host = node.fetch(:other_oc_host, ignore_flag)
+other_oc_prefother_series = node.fetch(:other_oc_prefother_series, ignore_flag)
+other_oc_preflocal_series = node.fetch(:other_oc_preflocal_series, ignore_flag)
+
 git_data = node[:deploy][:matterhorn][:scm]
 
 public_hostname = node[:opsworks][:instance][:public_dns_name]
@@ -108,7 +117,7 @@ deploy_revision "matterhorn" do
       most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated
     )
     install_live_streaming_service_config(most_recent_deploy, live_stream_name)
-    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
+    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host, other_oc_host, other_oc_prefother_series, other_oc_preflocal_series)
     install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_aws_s3_file_archive_service_config(most_recent_deploy, region, s3_file_archive_bucket_name)
     install_ibm_watson_transcription_service_config(most_recent_deploy, ibm_watson_username, ibm_watson_psw) 

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -29,6 +29,15 @@ auth_redirect_location = node.fetch(:auth_redirect_location, 'http://example.com
 auth_activated = node.fetch(:auth_activated, 'true')
 auth_key = node.fetch(:auth_key, '')
 
+# OPC-149 Other oc host for pub list merge
+# The ignore-flag default value signals the config consumer
+# That the value for the config was not intentionally set and should
+# be ignored.
+ignore_flag = 'IGNORE_ME'
+other_oc_host = node.fetch(:other_oc_host, ignore_flag)
+other_oc_prefother_series = node.fetch(:other_oc_prefother_series, ignore_flag)
+other_oc_preflocal_series = node.fetch(:other_oc_preflocal_series, ignore_flag)
+
 ## Engage specific
 user_tracking_authhost = node.fetch(
   :user_tracking_authhost, 'http://example.com'
@@ -101,7 +110,7 @@ deploy_revision "matterhorn" do
     # ENGAGE SPECIFIC
     set_service_registry_dispatch_interval(most_recent_deploy)
     configure_usertracking(most_recent_deploy, user_tracking_authhost)
-    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host)
+    install_otherpubs_service_config(most_recent_deploy, matterhorn_repo_root, auth_host, other_oc_host, other_oc_prefother_series, other_oc_preflocal_series)
     install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_aws_s3_distribution_service_config(most_recent_deploy, region, s3_distribution_bucket_name)
     # /ENGAGE SPECIFIC

--- a/templates/default/edu.harvard.dce.otherpubs.service.OtherpubsService.properties.erb
+++ b/templates/default/edu.harvard.dce.otherpubs.service.OtherpubsService.properties.erb
@@ -1,16 +1,48 @@
 # Configuration for DCE Other Publications Service
 
-# For other (Legacy) course publication metadatadata
-# Enable Access to Legacy SD publications
+# For other (Legacy and other Opencast) course publication metadatadata, default course data, system message
+# Enable Access to Legacy SD publications and system message
 # Used by Combo publication listing page
 
+# I. OPC-149 combo page with other opencast engage search (i.e. get 5x pubs if 1x, get 1x pubs if 5x)
+#
+# I.1. Uncomment the following "oc.dns" param line add a different Opencast ENGAGE dns (search service endpoint)
+#    to facilitate pulling in pubs from the other Opencast Engage onto this Engage's combo pub list.
+#    Note: Only local pub is shown when other system pub has an overlapping date. Otherwise, both are shown.
+#    Note: @other_oc_host is a cluster config param, set there to persist the setting across deploys.
+edu.harvard.dce.otherpubs.oc.dns=https://<%= @other_oc_host %>
+
+# I.2. Uncomment the following and add comma separated list of series where the Other Opencast
+#    system's pub takes precedence over local Opencast pubs when both have overlapping dates.
+#    NOTE: if the seriesId shows up in both prefother and preflocal, the preflocal takes precedence.
+#    Example: edu.harvard.dce.otherpubs.oc.prefother.series=20190119998,20190119999
+edu.harvard.dce.otherpubs.oc.prefother.series=<%= @other_oc_prefother_series %>
+
+# I.3. Uncomment the following and add comma separated list of series where the Local Opencast
+#    system's pub takes precedence over other Opencast pubs when both have overlapping dates.
+#    NOTE: if the seriesId shows up in both prefother and preflocal, the preflocal takes precedence.
+#    Example: edu.harvard.dce.otherpubs.oc.preflocal.series=20190119998,20190119999
+edu.harvard.dce.otherpubs.oc.preflocal.series=<%= @other_oc_preflocal_series %>
+
+# I.4. Omit series identifiers from both above lists to prevent other Opencast publications
+#    from showing up in the local publication listing page.
+#    Only local pubs will show up on the omitted series publication listing pages.
+
+# II. Retrieve the Legacy system message for display on combo page (active)
+# The following params are for the host system of the Legacy system note, the path of the note.
 edu.harvard.dce.otherpubs.dns=http://<%= @auth_host %>
 edu.harvard.dce.otherpubs.system.message.path.template=/includes/sys-msg.json
+# Depreciated: these are for the Legacy series note and old Legacy live and VOD pubs
 edu.harvard.dce.otherpubs.offering.message.path.template=/$year/$term/$crn/$crn-msg.json
 edu.harvard.dce.otherpubs.live.path.template=/classroom/publicationListing.json
 edu.harvard.dce.otherpubs.offering.pub.path.template=/$year/$term/$crn/publicationListing.json
 
-# For other (ac-web/Banner) course metadata data
+# III. TODO: the following was to retrieve course metadata from (ac-web/Banner).
+# This was abandoned because course metadata is not acceptably accurate from Banner (per producers)
+# and can not be updated there by producers (as of 2018). Legacy system is populated from Banner
+# and updated by producers. Legacy is still used to retrieve course metadata and scheduling
+# information (as of 2018). See MATT-1857 below.
+# ...
 # Enable Access to Banner episode metadata via the Otherpubs endpoint
 # Used by Admin UI schedule and upload UI auto-form fill by series id
 # edu.harvard.dce.otherpubs.coursedata.dns=https://ac-web.dce.harvard.edu
@@ -18,13 +50,17 @@ edu.harvard.dce.otherpubs.offering.pub.path.template=/$year/$term/$crn/publicati
 # edu.harvard.dce.otherpubs.coursedata.coursedetail.path.template=/rest/de/__get_course_details.php?term=$year$term&crn=$crn
 # edu.harvard.dce.otherpubs.coursedata.coursepeople.path.template=/rest/de/__get_course_people.php?term=$year$term&crn=$crn
 #
-# MATT-1857 Get episode defaults from S3 static JSON bucket extracted from Legacy by MatterhornEpisodeDefaultsDriver
+# IV. MATT-1857 Get episode defaults
+# The EpisodeDefaults.json originates from S3 static JSON bucket
+# that was extracted from Legacy by the Legacy driver MatterhornEpisodeDefaultsDriver
 # edu.harvard.dce.otherpubs.coursedata.dns=
 edu.harvard.dce.otherpubs.coursedata.courses.path.template=/EpisodeDefaults.json
 edu.harvard.dce.otherpubs.coursedata.coursedetail.path.template=/EpisodeDefaults.json
 edu.harvard.dce.otherpubs.coursedata.coursepeople.path.template=/EpisodeDefaults.json
+
 # MATT-1893 Get episode defaults from a local json file
 edu.harvard.dce.otherpubs.coursedata.dir=<%= @matterhorn_repo_root %>/current/etc/default_data
+
 # MATT-2215 Add log threshold for connection/read timeout in seconds
 # default is 3 minutes for connection time, and 0 for logging connection duration
 edu.harvard.dce.otherpubs.connectiontimethreshold=180


### PR DESCRIPTION
OPC-149 config to allow 1x combo pub list to pull from 5x engage server.

Includes documenting the params in otherpubs config template, adding an IGNORE-ME default value to alert otherpubs service that the params have not been intentionally set.

Note: there is an almost identical pull for the 5x to pull from 1x. https://github.com/harvard-dce/mh-opsworks-recipes/pull/178