### PR TITLE
OPC-226: redirect http -> https in engage nginx configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TO BE RELEASED
 
+* OPC-226: redirect http -> https in engage nginx configuration
 * MI-125: rename maven cache archive to distinguish 5x vs 1x
 * OPC-219: remove creation of `etc/opencast.conf` and allow enabling java debugging via `bin/setenv`
 * MATT-2324: In 5x, it's Ok remove LTI process filter proxy workaround. Has companion OC 5x change.

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -9,6 +9,12 @@ server {
   listen [::]:80 default_server ipv6only=on;
   directio 1M;
 
+  <% if @certificate_exists %>
+  location /admin-ng/login.html {
+    return 301 https://$host$request_uri;
+  }
+  <% end %>
+
   root /usr/share/nginx/html;
   index index.html index.htm;
 


### PR DESCRIPTION
I thought this was going to be all or nothing, but turns out to be easy to do the https redirect only for certain paths. The problem with doing everything is that the internal cluster communications can't handle the 301 redirect.

`/admin-ng` is a given, but I'd like confirmation that anything under the `/engage/...` path is also OK to force https. 