### PR TITLE
OPC-230 Optional 1x to 5x DNS forwarding (migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* OPC-230, optional cluster config param to proxy the 1x Engage to a 5x Engage. Works with Canvas LTI plugins.
+
 ## v1.34.1 - 11/02/2018
 
 * ensure the dist-upgrade runs with updated package repo && in non-interactive mode

--- a/recipes/configure-engage-nginx-proxy.rb
+++ b/recipes/configure-engage-nginx-proxy.rb
@@ -17,6 +17,9 @@ storage_info = node.fetch(
 
 shared_storage_root = get_shared_storage_root
 
+# OPC-230, optional param to direct 1x Engage calls to another Engage (i.e. 5x)
+proxy_5x_ip = node.fetch(:proxy_5x_ip, '')
+
 ssl_info = node.fetch(:ssl, get_dummy_cert)
 if cert_defined(ssl_info)
   create_ssl_cert(ssl_info)
@@ -38,7 +41,8 @@ template %Q|/etc/nginx/sites-enabled/default| do
   variables({
     shared_storage_root: shared_storage_root,
     matterhorn_backend_http_port: 8080,
-    certificate_exists: certificate_exists
+    certificate_exists: certificate_exists,
+    proxy_5x_ip: proxy_5x_ip
   })
 end
 

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -4,6 +4,13 @@ userid_expires max;
 
 log_format session_uid '$cookie_JSESSIONID $uid_got';
 
+<% if not @proxy_5x_ip.empty? %>
+# OPC-230 1x to 5x migration. 443 needed for SSL handshake
+upstream opencast_5x {
+   server <%= @proxy_5x_ip %>:443;
+}
+<% end %>
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server ipv6only=on;
@@ -15,6 +22,28 @@ server {
   # Make site accessible from http://localhost/
   server_name localhost;
 
+  # OPC-230 optional param for 1x to 5x migration DNS proxy
+<% if not @proxy_5x_ip.empty? %>
+  # OPC-230 forward all to the proxy 5x
+  location / {
+    proxy_pass https://opencast_5x/;
+  }
+
+<% else %>
+  location /static {
+    alias <%= @shared_storage_root %>/downloads;
+  }
+
+  location /usertracking {
+    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>/usertracking;
+    access_log /var/log/nginx/session_uid.log session_uid;
+    access_log /var/log/nginx/access.log request_time;
+  }
+
+  location / {
+    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>;
+  }
+<% end %>
   proxy_read_timeout 30m;
   proxy_send_timeout 30m;
   proxy_set_header Host $host;
@@ -29,19 +58,6 @@ server {
   add_header 'Access-Control-Allow-Credentials' 'true';
   add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
 
-  location /static {
-    alias <%= @shared_storage_root %>/downloads;
-  }
-
-  location /usertracking {
-    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>/usertracking;
-    access_log /var/log/nginx/session_uid.log session_uid;
-    access_log /var/log/nginx/access.log request_time;
-  }
-
-  location / {
-    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>;
-  }
 }
 
 <% if @certificate_exists %>
@@ -65,6 +81,30 @@ server {
   # Make site accessible from http://localhost/
   server_name localhost;
 
+<% if not @proxy_5x_ip.empty? %>
+  # OPC-230 forward all to the proxy 5x
+  location / {
+    proxy_pass https://opencast_5x/;
+  }
+
+<% else %>
+
+   location /static {
+    alias <%= @shared_storage_root %>/downloads;
+  }
+
+  location /usertracking {
+    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>/usertracking;
+    access_log /var/log/nginx/session_uid.log session_uid;
+    access_log /var/log/nginx/access.log request_time;
+  }
+
+  location / {
+    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>;
+  }
+
+<% end %>
+
   proxy_read_timeout 30m;
   proxy_send_timeout 30m;
   proxy_set_header Host $host;
@@ -84,18 +124,5 @@ server {
   add_header 'Access-Control-Allow-Credentials' 'true';
   add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
 
-  location /static {
-    alias <%= @shared_storage_root %>/downloads;
-  }
-
-  location /usertracking {
-    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>/usertracking;
-    access_log /var/log/nginx/session_uid.log session_uid;
-    access_log /var/log/nginx/access.log request_time;
-  }
-
-  location / {
-    proxy_pass http://127.0.0.1:<%= @matterhorn_backend_http_port %>;
-  }
 }
 <% end %>


### PR DESCRIPTION
An optional param to change 1x Engage nginx  to be served by 5x Engage,

Tested three cases:

1. The "proxy_5x_ip" custom param has 5x Engage public IP value: All calls to the 1x Engage are served by the 5x engage.
...
     "chef": {
       "custom_json": {
+        "proxy_5x_ip": "100.24.88.56",
         "chef_log_level": "debug",

2. Empty "proxy_5x_ip" custom param: 1x Engage nginx behaves as before (serves it's own calls)
...
     "chef": {
       "custom_json": {
+        "proxy_5x_ip": "",
         "chef_log_level": "debug",

3. No "proxy_5x_ip" custom param: 1x Engage nginx behaves as before (serves its own calls)
...
     "chef": {
       "custom_json": {
         "chef_log_level": "debug",