### PR TITLE
MATT-2324 removing lti process filter workaround for 5x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MI-125: rename maven cache archive to distinguish 5x vs 1x
 * OPC-219: remove creation of `etc/opencast.conf` and allow enabling java debugging via `bin/setenv`
+* MATT-2324: In 5x, it's Ok remove LTI process filter proxy workaround. Has companion OC 5x change.
 
 ## v1.34.1 - 11/02/2018
 

--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -500,11 +500,6 @@
   </bean>
 
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
-    <!-- start #DCE MATT-2046 proxy workaround params, comment these out if external and internal URLs match
-    The arg 0 is the String urlSentByLtiClient, the arg 1 is String urlUsedByProxyServer -->
-    <constructor-arg index="0" value = "https://<%= @proxy_name %>/lti" />
-    <constructor-arg index="1" value = "http://<%= @unproxied_name %>/lti" />
-    <!-- end MATT-2046 proxy workaround params -->
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
       <bean class="org.springframework.security.oauth.provider.token.InMemoryProviderTokenServices" />


### PR DESCRIPTION
Ref QA ticket QA-726 
The current nginx configuration in 5x allows the old MATT-2324 Oauth signature workaround to be removed.

This has a companion DCE Opencast 5x pull:
https://bitbucket.org/hudcede/matterhorn-dce-fork/pull-requests/432