### PR TITLE
MI-140: index removal script now uses correct solr index path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * MI-133: remove recipe for building enhanced networking kernel module
 * updating some references to the "dont_start_matterhorn_automatically" flag
 * MI-138: generate a cloudwatch metric based on Opencast's job load
+* MI-140: cluster reset scripts now use correct solr indices path
 
 ## v1.34.1 - 11/02/2018
 

--- a/files/default/remove-indexes.sh
+++ b/files/default/remove-indexes.sh
@@ -22,7 +22,7 @@ done
 
 if ! $do_it; then
   echo
-  echo "Usage: remove-solr-indexes.sh -x -p <full path to indexes>"
+  echo "Usage: remove-indexes.sh -x -p <full path to indexes>"
   echo
   echo " -x	Actually remove the indexes"
   echo " -p	the full path to the root directory of the indexes, probably the local workspace"
@@ -35,4 +35,8 @@ if [ -z "$index_path" ]; then
   exit 1
 fi
 
-/bin/rm -Rf $index_path/*index/
+# elasticsearch indexes
+/bin/rm -Rf $index_path/index/data
+
+# solr indexes
+/bin/rm -Rf $index_path/solr-indexes/*

--- a/recipes/remove-admin-indexes.rb
+++ b/recipes/remove-admin-indexes.rb
@@ -6,17 +6,18 @@ do_it = node.fetch(:do_it, false)
 local_workspace_root = get_local_workspace_root
 
 if dev_or_testing_cluster?
-  cookbook_file 'remove-solr-indexes.sh' do
-    path '/usr/local/bin/remove-solr-indexes.sh'
+  cookbook_file 'remove-indexes.sh' do
+    path '/usr/local/bin/remove-indexes.sh'
     owner 'root'
     group 'root'
     mode '755'
   end
 
   if do_it && admin_node?
-    execute 'remove admin solr indexes' do
+    execute 'remove admin solr and elasticsearch indexes' do
       user 'opencast'
-      command %Q|/usr/local/bin/remove-solr-indexes.sh -x -p #{local_workspace_root}|
+      command %Q|/usr/local/bin/remove-indexes.sh -x -p #{local_workspace_root}|
     end
+
   end
 end

--- a/recipes/remove-engage-indexes.rb
+++ b/recipes/remove-engage-indexes.rb
@@ -6,17 +6,17 @@ do_it = node.fetch(:do_it, false)
 local_workspace_root = get_local_workspace_root
 
 if dev_or_testing_cluster?
-  cookbook_file 'remove-solr-indexes.sh' do
-    path '/usr/local/bin/remove-solr-indexes.sh'
+  cookbook_file 'remove-indexes.sh' do
+    path '/usr/local/bin/remove-indexes.sh'
     owner 'root'
     group 'root'
     mode '755'
   end
 
   if do_it && engage_node?
-    execute 'remove engage solr indexes' do
+    execute 'remove engage solr and elasticsearch indexes' do
       user 'opencast'
-      command %Q|/usr/local/bin/remove-solr-indexes.sh -x -p #{local_workspace_root}|
+      command %Q|/usr/local/bin/remove-indexes.sh -x -p #{local_workspace_root}|
     end
   end
 end


### PR DESCRIPTION
This script is used during the `cluster:reset` task.
Also added removal of elasticsearch index data.