### PR TITLE
Oc v2.0.0 rc2 with OPC-226 and typo fix from original 1x to 5x conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TO BE RELEASED
 
 * MI-97: update mysql alarms for rds aurora cluster
+* OPC-226: redirect http -> https in engage nginx configuration
 * MI-125: rename maven cache archive to distinguish 5x vs 1x
 * OPC-219: remove creation of `etc/opencast.conf` and allow enabling java debugging via `bin/setenv`
 * MATT-2324: In 5x, it's Ok remove LTI process filter proxy workaround. Has companion OC 5x change.

--- a/recipes/configure-engage-nginx-proxy.rb
+++ b/recipes/configure-engage-nginx-proxy.rb
@@ -9,6 +9,8 @@ install_nginx_logrotate_customizations
 
 shared_storage_root = get_shared_storage_root
 
+public_engage_hostname = get_public_engage_hostname
+
 ssl_info = node.fetch(:ssl, get_dummy_cert)
 if cert_defined(ssl_info)
   create_ssl_cert(ssl_info)
@@ -32,7 +34,8 @@ template 'proxy' do
   variables({
     shared_storage_root: shared_storage_root,
     opencast_backend_http_port: 8080,
-    certificate_exists: certificate_exists
+    certificate_exists: certificate_exists,
+    public_engage_hostname: public_engage_hostname
   })
 end
 

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -9,6 +9,12 @@ server {
   listen [::]:80 default_server ipv6only=on;
   directio 1M;
 
+  <% if @certificate_exists %>
+  location /admin-ng/login.html {
+    return 301 https://$host$request_uri;
+  }
+  <% end %>
+
   root /usr/share/nginx/html;
   index index.html index.htm;
 
@@ -75,7 +81,9 @@ server {
   # Ask opencast to redirect to HTTPS
   proxy_set_header X-Forwarded-SSL on;
   # Rewrite outgoing redirects to be HTTPS
-  proxy_redirect http://opencast.dce.harvard.edu/ https://opencast.dce.harvard.edu/;
+  proxy_redirect http://<%= @public_engage_hostname %>/ https://<%= @public_engage_hostname %>/;
+  # Include the old static DNS to protect legacy links
+  proxy_redirect http://matterhorn.dce.harvard.edu/ https://matterhorn.dce.harvard.edu/;
 
   client_max_body_size 102400m;
   gzip on;


### PR DESCRIPTION
@lbjay This is the same as the OPC-266 pull but it fixes a 1x to 5x text-substitution typo in the proxy_redirect area of the Engage nginx. The fix resolves the issue where logging into the https://<DNS engage node>/... page changes back to http://<DNS engage node>... after login.
Tested with publish and retract on rute prod 5x migration cluster and social notes and pub list on harvard canvas sandbox (last two nav entries)