### PR TITLE
t/OPC-314-editor-shortcut-display

### DIFF
--- a/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
+++ b/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
@@ -348,6 +348,7 @@ prop.show_embed_links=true
 #   - down
 #   - ins
 #   - del
+#   - plus
 # - any other key
 #   - should be referenceable by name like a, /, $, *, or =
 # - for more information have a look at the player docs
@@ -372,7 +373,8 @@ prop.player.shortcut.zoom.moveLeft=a
 prop.player.shortcut.zoom.moveRight=d
 prop.player.shortcut.zoom.moveUp=w
 prop.player.shortcut.zoom.moveDown=s
-prop.player.shortcut.zoom.in=+
+## DCE t/OPC-314 - OC MH-12911
+prop.player.shortcut.zoom.in=plus
 prop.player.shortcut.zoom.out=-
 
 prop.player.shortcut-sequence=controls,volume,playbackrate,layout,zoom,fullscreen
@@ -386,7 +388,8 @@ prop.admin.shortcut.player.previous_segment=up
 prop.admin.shortcut.player.next_segment=down
 prop.admin.shortcut.player.step_backward=ctrl+left
 prop.admin.shortcut.player.step_forward=ctrl+right
-prop.admin.shortcut.player.volume_up=+
+## DCE t/OPC-314 - OC MH-12911
+prop.admin.shortcut.player.volume_up=plus
 prop.admin.shortcut.player.volume_down=-
 prop.admin.shortcut.player.mute=m
 
@@ -413,7 +416,9 @@ prop.admin.shortcut.general.remove_filters=r
 prop.admin.shortcut.general.select_next_dashboard_filter=f
 prop.admin.shortcut.general.select_previous_dashboard_filter=F
 prop.admin.shortcut.general.main_menu=m
-prop.admin.shortcut.general.help=?
+
+## DCE t/OPC-314 (OC MH-12911) - Disable it to use a new cheatsheet
+# prop.admin.shortcut.general.help=?
 
 # Default values for a few fields in New Event Creation modal
 #


### PR DESCRIPTION
Disable default help shortcut to display cheatsheet. This is the companion PR to the one of the same name in hudcede/matterhorn-dce-fork