### PR TITLE
MI-162: new recipe to enable ubuntu advantage esm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* MI-162: new recipe to enable ubuntu advantage esm
+
 ## v2.6.0 - 04/23/2019
 
 * OPC-340: producer permission for DCE stop-start scheduler endpoints

--- a/metadata.rb
+++ b/metadata.rb
@@ -1046,6 +1046,18 @@ none
 * will install and enable the aws-tuned v4 linux kernel
 '
 )
+recipe(
+    'oc-opsworks-recipes::enable-ubuntu-advantage-esm',
+    'Runs the `ubuntu-advantage enable-esm` command.
+
+=== attributes
+none
+
+=== effects
+* Will execute the enable-esm command with the user/pass combo
+  configured in the cluster config "ubuntu_advantage_esm"
+'
+)
 depends 'nfs', '~> 2.1.0'
 depends 'apt', '~> 2.9.2'
 depends 'cron', '~> 1.6.1'

--- a/recipes/enable-ubuntu-advantage-esm.rb
+++ b/recipes/enable-ubuntu-advantage-esm.rb
@@ -1,0 +1,16 @@
+# Cookbook Name:: oc-opsworks-recipes
+# Recipe:: enable-ubuntu-advantage-esm
+
+::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
+install_package('apt apt-transport-https apt-utils libapt-inst1.5 libapt-pkg4.12 ubuntu-advantage-tools')
+
+esm_auth = node.fetch(:ubuntu_advantage_esm, {})
+return if esm_auth.empty?
+
+execute "enable esm" do
+  command %Q|ubuntu-advantage enable-esm #{esm_auth[:user]}:#{esm_auth[:password]}|
+  retries 5
+  retry_delay 15
+  not_if "sudo apt-cache policy | grep -i esm"
+end
+

--- a/recipes/install-oc-base-packages.rb
+++ b/recipes/install-oc-base-packages.rb
@@ -4,6 +4,7 @@
 ::Chef::Recipe.send(:include, MhOpsworksRecipes::RecipeHelpers)
 
 include_recipe "oc-opsworks-recipes::update-package-repo"
+include_recipe "oc-opsworks-recipes::enable-ubuntu-advantage-esm"
 
 packages = %Q|autofs5 curl dkms gzip jq libglib2.0-dev mysql-client postfix python-pip python-dev rsyslog-gnutls run-one tesseract-ocr|
 install_package(packages)


### PR DESCRIPTION
This recipe will execute the `ubuntu-advantage enable-esm` command with the user/password combo from the cluster config's `ubuntu_advantage_esm` block. 

These values have already been added to `base-secrets.json` in both accounts. 

Existing cluster configs will need to be updated manually. 

Because the recipe gets included by `install-oc-base-packages` it will get run during normal cluster startup.