### PR TITLE
OPC-139 lti content object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TO BE RELEASED
 
+* OPC-139 LTI Oauth config change from Upstream
 * MI-164: set nginx logrotate to only keep 30 
 * MI-171: nginx config reload needs to watch for changes to both the ssl key *and* cert
 
@@ -29,7 +30,6 @@
 +                  <queue physicalName="SCHEDULER.CaptureAgentSync" />
                    <queue physicalName="SCHEDULER.Liveschedule" />
                  </forwardTo>
-
 
 ## v2.7.1 - 04/26/2019
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -937,6 +937,18 @@ module MhOpsworksRecipes
       )
     end
 
+   def install_oauthconsumerdetails_service_config(current_deploy_root)
+      lti_oauth_info = get_lti_auth_info
+      template %Q|#{current_deploy_root}/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg| do
+        source 'org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg.erb'
+        owner 'opencast'
+        group 'opencast'
+        variables({
+          lti_oauth: lti_oauth_info
+        })
+      end
+    end
+
     def install_smtp_config(current_deploy_root)
       smtp_auth = node.fetch(:smtp_auth, {})
       default_email_sender = smtp_auth.fetch(:default_email_sender, 'no-reply@localhost')

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -736,6 +736,7 @@ module MhOpsworksRecipes
       oc_log_dir = node.fetch(:opencast_log_directory, '/var/log/opencast')
       oc_log_level = node.fetch(:opencast_log_level, 'INFO')
       dce_log_level = node.fetch(:dce_log_level, 'DEBUG')
+      hostname = node[:opsworks][:instance][:hostname]
       template %Q|#{current_deploy_root}/etc/org.ops4j.pax.logging.cfg| do
         source 'org.ops4j.pax.logging.cfg.erb'
         owner 'opencast'
@@ -743,7 +744,8 @@ module MhOpsworksRecipes
         variables ({
             opencast_log_directory: oc_log_dir,
             opencast_log_level: oc_log_level,
-            dce_log_level: dce_log_level
+            dce_log_level: dce_log_level,
+            log_event_hostname: hostname
         })
       end
     end

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -161,6 +161,9 @@ deploy_revision "opencast" do
 #    configure_usertracking(most_recent_deploy, user_tracking_authhost)
     install_aws_s3_distribution_service_config(most_recent_deploy, enable_s3, region, s3_distribution_bucket_name, s3_distribution_base_url)
 #    install_opencast_images_properties(most_recent_deploy)
+    # OPC-139 Oauth config (for Engage)
+    install_oauthconsumerdetails_service_config(most_recent_deploy)
+
     # /all-in-one SPECIFIC
 
     if using_local_distribution

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -123,6 +123,8 @@ deploy_revision "opencast" do
     install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_bug_report_email(most_recent_deploy, public_engage_hostname)
     install_aws_s3_distribution_service_config(most_recent_deploy, enable_s3, region, s3_distribution_bucket_name, s3_distribution_base_url)
+    # OPC-139 Oauth config
+    install_oauthconsumerdetails_service_config(most_recent_deploy)
     # /ENGAGE SPECIFIC
 
     template %Q|#{most_recent_deploy}/etc/custom.properties| do

--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -319,6 +319,7 @@
 
     <!-- Enable 2-legged OAuth access ("signed fetch") to the LTI launch servlet -->
     <sec:intercept-url pattern="/lti" access="ROLE_OAUTH_USER" />
+    <sec:intercept-url pattern="/lti/**" access="ROLE_OAUTH_USER" />
 
     <!-- Enable access to the LTI tools -->
     <sec:intercept-url pattern="/ltitools/**" access="ROLE_OAUTH_USER" />

--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -499,13 +499,6 @@
   <!-- This is required for LTI. If you are using LTI and have enabled the oauthProtectedResourceFilter  -->
   <!-- in the list of authenticationFilters above, set custom values for CONSUMERKEY and CONSUMERSECRET. -->
 
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="<%= @lti_oauth[:consumerkey] %>" />
-    <constructor-arg index="2" value="<%= @lti_oauth[:sharedsecret] %>" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -514,24 +507,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-
-        <!-- Uncomment to trust usernames from the LTI consumer identified by CONSUMERKEY.           -->
-        <!-- Users from untrusted systems will be prefixed with "lti:" and the consumer domain name. -->
-
-        <!--
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>CONSUMERKEY</value>
-          </list>
-        </constructor-arg>
-        -->
-
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>  
 
 <%# ----------------------------------------- %>
@@ -641,6 +617,13 @@
 
   <osgi:reference id="userDirectoryService" cardinality="1..1"
                   interface="org.opencastproject.security.api.UserDirectoryService" />
+
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
+
 
 <%# ----------------------------------------- %>
 <%# This is only included if ldap is enabled. %>

--- a/templates/default/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg.erb
+++ b/templates/default/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg.erb
@@ -1,0 +1,8 @@
+# OAuth consumer consisting of name, key and secret.
+#
+# Multiple OAuth consumers can be configured, by incrementing the counter. The list is read
+# sequentially incrementing the counter. If you miss any numbers it will stop looking for
+# further consumers.
+oauth.consumer.name.1=OPENCAST_LTI_CONSUMER
+oauth.consumer.key.1=<%= @lti_oauth[:consumerkey] %>
+oauth.consumer.secret.1=<%= @lti_oauth[:sharedsecret] %>

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -41,27 +41,27 @@ log4j2.logger.cxf.level = WARN
 
 # DCE-added
 # Helps to have these at DEBUG level or accessible to toggle to DEBUG as needed
-log4j.logger.opencastproject.lti.name = org.opencast.project.lti.LtiServlet
-log4j.logger.opencastproject.lti.level = DEBUG
-log4j.logger.opencastproject.liveschedule.name = org.opencastproject.liveschedule
-log4j.logger.opencastproject.liveschedule.level = INFO
-log4j.logger.opencastproject.captureagentsync.name = org.opencastproject.captureagentsync
-log4j.logger.opencastproject.captureagentsync.level = DEBUG
+log4j2.logger.lti.name = org.opencast.project.lti.LtiServlet
+log4j2.logger.lti.level = DEBUG
+log4j2.logger.liveschedule.name = org.opencastproject.liveschedule
+log4j2.logger.liveschedule.level = INFO
+log4j2.logger.captureagentsync.name = org.opencastproject.captureagentsync
+log4j2.logger.captureagentsync.level = DEBUG
 
 # DCE-added
 # Helps to leave these at INFO level while debugging general opencast classes
-log4j.logger.opencastproject.ingest.scanner.name = org.opencastproject.ingest.scanner.Ingestor
-log4j.logger.opencastproject.ingest.scanner.level = INFO
-log4j.logger.opencastproject.kernel.jsonfilter.name = org.opencastproject.kernel.rest.JsonpFilter
-log4j.logger.opencastproject.kernel.jsonfilter.level = INFO
-log4j.logger.opencastproject.kernel.TrustedAnonAuthFilter.name = org.opencastproject.kernel.security.TrustedAnonymousAuthenticationFilter
-log4j.logger.opencastproject.kernel.TrustedAnonAuthFilter.level=INFO
-log4j.logger.opencastproject.kernel.TrustedHttpClient.name = org.opencastproject.kernel.security.TrustedHttpClientImpl
-log4j.logger.opencastproject.kernel.TrustedHttpClient.level = INFO
-log4j.logger.opencastproject.kernel.HttpClient.name = org.opencastproject.kernel.http.impl.HttpClientImpl
-log4j.logger.opencastproject.kernel.HttpClient.level = INFO
-log4j.logger.springframework.AnonAuthFilter.name = org.security.web.authentication.AnonymousAuthenticationFilter
-log4j.logger.springframework.AnonAuthFilter.level = INFO
+log4j2.logger.scanner.name = org.opencastproject.ingest.scanner.Ingestor
+log4j2.logger.scanner.level = INFO
+log4j2.logger.kerneljsonfilter.name = org.opencastproject.kernel.rest.JsonpFilter
+log4j2.logger.kerneljsonfilter.level = INFO
+log4j2.logger.kernelTrustedAnonAuthFilter.name = org.opencastproject.kernel.security.TrustedAnonymousAuthenticationFilter
+log4j2.logger.kernelTrustedAnonAuthFilter.level=INFO
+log4j2.logger.kernelTrustedHttpClient.name = org.opencastproject.kernel.security.TrustedHttpClientImpl
+log4j2.logger.kernelTrustedHttpClient.level = INFO
+log4j2.logger.kernelHttpClient.name = org.opencastproject.kernel.http.impl.HttpClientImpl
+log4j2.logger.kernelHttpClient.level = INFO
+log4j2.logger.SpringframeworkAnonAuthFilter.name = org.security.web.authentication.AnonymousAuthenticationFilter
+log4j2.logger.springframeworkAnonAuthFilter.level = INFO
 
 # Appenders configuration
 
@@ -93,11 +93,11 @@ log4j2.appender.osgi.filter = *
 # Syslog
 # see: https://logging.apache.org/log4j/2.x/manual/appenders.html#SyslogAppender
 # also see: https://logging.apache.org/log4j/2.x/manual/migration.html
-log4j.appender.SYSLOG.name = org.apache.log4j.net.SyslogAppender
-log4j.appender.SYSLOG.host = localhost
-log4j.appender.SYSLOG.facility = LOCAL3
+log4j2.appender.SYSLOG.name = org.apache.log4j.net.SyslogAppender
+log4j2.appender.SYSLOG.host = localhost
+log4j2.appender.SYSLOG.facility = LOCAL3
 # is there a  migration for this param? log4j.appender.SYSLOG.Header = true
-log4j.appender.SYSLOG.layout.type = PatternLayout
-log4j.appender.SYSLOG.layout.pattern = opencast %p %t %c{1}.%M - %m %throwable%n
+log4j2.appender.SYSLOG.layout.type = PatternLayout
+log4j2.appender.SYSLOG.layout.pattern = opencast %p %t %c{1}.%M - %m %throwable%n
 
 

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -73,17 +73,17 @@ log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
 
 # Rolling file appender
 log4j2.appender.out.type = RollingFile
-log4j2.appender.out.name = RollingFile
+log4j2.appender.out.name = File
 log4j2.appender.out.fileName=<%= @opencast_log_directory %>/opencast.log
 log4j2.appender.out.filePattern=<%= @opencast_log_directory %>/opencast.log.%d{yyyy-MM-dd}
 log4j2.appender.out.append = true
 log4j2.appender.out.immediateFlush = true
 log4j2.appender.out.layout.type = PatternLayout
 log4j2.appender.out.layout.pattern = ${log4j2.pattern}
+log4j2.appender.out.policies.type = Policies
 log4j2.appender.out.policies.time.type = TimeBasedTriggeringPolicy
-log4j2.appender.out.policies.time.interval = 1 # "1" is Daily rollover
+log4j2.appender.out.policies.time.interval = 1
 log4j2.appender.out.policies.time.modulate = true
-log4j2.appender.out.encoding = UTF-8
 
 # OSGi appender
 log4j2.appender.osgi.type = PaxOsgi

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -39,6 +39,30 @@ log4j2.logger.felix.level = WARN
 log4j2.logger.cxf.name = org.apache.cxf
 log4j2.logger.cxf.level = WARN
 
+# DCE-added
+# Helps to have these at DEBUG level or accessible to toggle to DEBUG as needed
+log4j.logger.opencastproject.lti.name = org.opencast.project.lti.LtiServlet
+log4j.logger.opencastproject.lti.level = DEBUG
+log4j.logger.opencastproject.liveschedule.name = org.opencastproject.liveschedule
+log4j.logger.opencastproject.liveschedule.level = INFO
+log4j.logger.opencastproject.captureagentsync.name = org.opencastproject.captureagentsync
+log4j.logger.opencastproject.captureagentsync.level = DEBUG
+
+# DCE-added
+# Helps to leave these at INFO level while debugging general opencast classes
+log4j.logger.opencastproject.ingest.scanner.name = org.opencastproject.ingest.scanner.Ingestor
+log4j.logger.opencastproject.ingest.scanner.level = INFO
+log4j.logger.opencastproject.kernel.jsonfilter.name = org.opencastproject.kernel.rest.JsonpFilter
+log4j.logger.opencastproject.kernel.jsonfilter.level = INFO
+log4j.logger.opencastproject.kernel.TrustedAnonAuthFilter.name = org.opencastproject.kernel.security.TrustedAnonymousAuthenticationFilter
+log4j.logger.opencastproject.kernel.TrustedAnonAuthFilter.level=INFO
+log4j.logger.opencastproject.kernel.TrustedHttpClient.name = org.opencastproject.kernel.security.TrustedHttpClientImpl
+log4j.logger.opencastproject.kernel.TrustedHttpClient.level = INFO
+log4j.logger.opencastproject.kernel.HttpClient.name = org.opencastproject.kernel.http.impl.HttpClientImpl
+log4j.logger.opencastproject.kernel.HttpClient.level = INFO
+log4j.logger.springframework.AnonAuthFilter.name = org.security.web.authentication.AnonymousAuthenticationFilter
+log4j.logger.springframework.AnonAuthFilter.level = INFO
+
 # Appenders configuration
 
 # Console appender not used by default (see log4j2.rootLogger.appenderRefs)
@@ -59,3 +83,15 @@ log4j2.appender.out.layout.pattern = ${log4j2.pattern}
 log4j2.appender.osgi.type = PaxOsgi
 log4j2.appender.osgi.name = PaxOsgi
 log4j2.appender.osgi.filter = *
+
+# Syslog
+# see: https://logging.apache.org/log4j/2.x/manual/appenders.html#SyslogAppender
+# and: https://logging.apache.org/log4j/2.x/manual/migration.html
+log4j.appender.SYSLOG.name = org.apache.log4j.net.SyslogAppender
+log4j.appender.SYSLOG.host = localhost
+log4j.appender.SYSLOG.facility = LOCAL3
+# is there a  migration for this param? log4j.appender.SYSLOG.Header = true
+log4j.appender.SYSLOG.layout.type = PatternLayout
+log4j.appender.SYSLOG.layout.pattern = opencast %p %t %c{1}.%M - %m %throwable%n
+
+

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -72,12 +72,18 @@ log4j2.appender.console.layout.type = PatternLayout
 log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
 
 # Rolling file appender
-log4j2.appender.out.type = RandomAccessFile
-log4j2.appender.out.name = File
+log4j2.appender.out.type = RollingFile
+log4j2.appender.out.name = RollingFile
 log4j2.appender.out.fileName=<%= @opencast_log_directory %>/opencast.log
+log4j2.appender.out.filePattern=<%= @opencast_log_directory %>/opencast.log.%d{yyyy-MM-dd}
 log4j2.appender.out.append = true
+log4j2.appender.out.immediateFlush = true
 log4j2.appender.out.layout.type = PatternLayout
 log4j2.appender.out.layout.pattern = ${log4j2.pattern}
+log4j2.appender.out.policies.time.type = TimeBasedTriggeringPolicy
+log4j2.appender.out.policies.time.interval = 1 # "1" is Daily rollover
+log4j2.appender.out.policies.time.modulate = true
+log4j2.appender.out.encoding = UTF-8
 
 # OSGi appender
 log4j2.appender.osgi.type = PaxOsgi
@@ -86,7 +92,7 @@ log4j2.appender.osgi.filter = *
 
 # Syslog
 # see: https://logging.apache.org/log4j/2.x/manual/appenders.html#SyslogAppender
-# and: https://logging.apache.org/log4j/2.x/manual/migration.html
+# also see: https://logging.apache.org/log4j/2.x/manual/migration.html
 log4j.appender.SYSLOG.name = org.apache.log4j.net.SyslogAppender
 log4j.appender.SYSLOG.host = localhost
 log4j.appender.SYSLOG.facility = LOCAL3

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -42,7 +42,7 @@ log4j2.logger.cxf.level = WARN
 
 # DCE-added
 # Helps to have these at DEBUG level or accessible to toggle to DEBUG as needed
-log4j2.logger.lti.name = org.opencast.project.lti.LtiServlet
+log4j2.logger.lti.name = org.opencastproject.lti.LtiServlet
 log4j2.logger.lti.level = DEBUG
 log4j2.logger.liveschedule.name = org.opencastproject.liveschedule
 log4j2.logger.liveschedule.level = INFO

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -14,6 +14,7 @@ log4j2.rootLogger.level = WARN
 log4j2.rootLogger.appenderRef.File.ref = File
 log4j2.rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
 log4j2.rootLogger.appenderRef.Console.ref = Console
+log4j2.rootLogger.appenderRef.syslog.ref = syslog
 log4j2.rootLogger.appenderRef.Console.filter.threshold.type = ThresholdFilter
 log4j2.rootLogger.appenderRef.Console.filter.threshold.level = ${karaf.log.console:-OFF}
 
@@ -60,7 +61,7 @@ log4j2.logger.kernelTrustedHttpClient.name = org.opencastproject.kernel.security
 log4j2.logger.kernelTrustedHttpClient.level = INFO
 log4j2.logger.kernelHttpClient.name = org.opencastproject.kernel.http.impl.HttpClientImpl
 log4j2.logger.kernelHttpClient.level = INFO
-log4j2.logger.SpringframeworkAnonAuthFilter.name = org.security.web.authentication.AnonymousAuthenticationFilter
+log4j2.logger.springframeworkAnonAuthFilter.name = org.security.web.authentication.AnonymousAuthenticationFilter
 log4j2.logger.springframeworkAnonAuthFilter.level = INFO
 
 # Appenders configuration
@@ -93,11 +94,15 @@ log4j2.appender.osgi.filter = *
 # Syslog
 # see: https://logging.apache.org/log4j/2.x/manual/appenders.html#SyslogAppender
 # also see: https://logging.apache.org/log4j/2.x/manual/migration.html
-log4j2.appender.SYSLOG.name = org.apache.log4j.net.SyslogAppender
-log4j2.appender.SYSLOG.host = localhost
-log4j2.appender.SYSLOG.facility = LOCAL3
-# is there a  migration for this param? log4j.appender.SYSLOG.Header = true
-log4j2.appender.SYSLOG.layout.type = PatternLayout
-log4j2.appender.SYSLOG.layout.pattern = opencast %p %t %c{1}.%M - %m %throwable%n
-
+log4j2.appender.syslog.type = Syslog
+log4j2.appender.syslog.name = syslog
+log4j2.appender.syslog.appName = opencast
+log4j2.appender.syslog.host = localhost
+log4j2.appender.syslog.facility = LOCAL1
+log4j2.appender.syslog.port = 514
+log4j2.appender.syslog.newLine = true
+log4j2.appender.syslog.ignoreExceptions = false
+log4j2.appender.syslog.protocol = UDP
+log4j2.appender.syslog.layout.type = PatternLayout
+log4j2.appender.syslog.layout.pattern = <%= @log_event_hostname %> opencast %p %t (%c{1}.%M:%L) - %m%n %throwable{separator(|)}
 

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -1,51 +1,61 @@
-# Root logger configuration.  This defines the default values to be used.  They may be overwritten by more specific
-# settings below.
-log4j.rootLogger=WARN, out, osgi:*, SYSLOG
-log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
+# Colors for log level rendering
+color.fatal = bright red
+color.error = bright red
+color.warn = bright yellow
+color.info = bright green
+color.debug = cyan
+color.trace = cyan
+
+# Common pattern layout for appenders
+log4j2.pattern =  %d{ISO8601} | %-5.5p | (%C{1}:%L) - %m%n
+
+# Root logger
+log4j2.rootLogger.level = WARN
+log4j2.rootLogger.appenderRef.File.ref = File
+log4j2.rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
+log4j2.rootLogger.appenderRef.Console.ref = Console
+log4j2.rootLogger.appenderRef.Console.filter.threshold.type = ThresholdFilter
+log4j2.rootLogger.appenderRef.Console.filter.threshold.level = ${karaf.log.console:-OFF}
+
+# Loggers configuration
 
 # Loglevel configuration for all opencast modules. Usually, INFO is a quite sane log level. If you need a different
 # detail level of logs, you can adjust this to: ERROR, WARN, INFO, DEBUG, TRACE.
-log4j.logger.org.opencastproject=<%= @opencast_log_level %>
-log4j.logger.edu.harvard.dce=<%= @dce_log_level %>
+log4j2.logger.opencast.name = org.opencastproject
+log4j2.logger.opencast.level = <%= @opencast_log_level %>
+log4j2.logger.hudce.name = edu.harvard.dce
+log4j2.logger.hudce.level = <%= @dce_log_level %>
 
 # You can specify different log levels for different packages/modules by specifying their package component names. For
 # example, to raise the log level to DEBUG for the rest endpoints contained in the kernel module, set:
-# log4j.logger.org.opencastproject.kernel.rest=DEBUG
+#log4j2.logger.ingest.name = org.opencastproject.ingest
+#log4j2.logger.ingest.level = DEBUG
 
 # For Karaf, Felix & CXF, we want to see some more details in the logs
-log4j.logger.org.apache.karaf=WARN
-log4j.logger.org.apache.felix=WARN
-log4j.logger.org.apache.cxf=WARN
+log4j2.logger.karaf.name = org.apache.karaf
+log4j2.logger.karaf.level = WARN
+log4j2.logger.felix.name = org.apache.felix
+log4j2.logger.felix.level = WARN
+log4j2.logger.cxf.name = org.apache.cxf
+log4j2.logger.cxf.level = WARN
 
-# DCE-added
-log4j.logger.org.opencastproject.ingest.scanner.Ingestor=INFO
-log4j.logger.org.opencastproject.kernel.rest.JsonpFilter=INFO
-log4j.logger.org.opencastproject.kernel.security.TrustedAnonymousAuthenticationFilter=INFO
-log4j.logger.org.springframework.security.web.authentication.AnonymousAuthenticationFilter=INFO
-log4j.logger.org.opencastproject.kernel.security.TrustedHttpClientImpl=INFO
-log4j.logger.org.opencastproject.kernel.http.impl.HttpClientImpl=INFO
-log4j.logger.org.opencastproject.lti.LtiServlet=DEBUG
-log4j.logger.org.opencastproject.liveschedule=INFO
-log4j.logger.org.opencastproject.captureagentsync=DEBUG
+# Appenders configuration
 
-# Console appender not used by default
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} | %-5.5p | (%C{1}:%L) - %m%n
+# Console appender not used by default (see log4j2.rootLogger.appenderRefs)
+log4j2.appender.console.type = Console
+log4j2.appender.console.name = Console
+log4j2.appender.console.layout.type = PatternLayout
+log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
 
-# File appender
-log4j.appender.out=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.out.layout=org.apache.log4j.PatternLayout
-log4j.appender.out.layout.ConversionPattern=%d{ISO8601} | %-5.5p | (%C{1}:%L) - %m%n
-log4j.appender.out.file=<%= @opencast_log_directory %>/opencast.log
-log4j.appender.out.append=true
-log4j.appender.out.encoding=UTF-8
-log4j.appender.out.DatePattern='.'yyyy-MM-dd
+# Rolling file appender
+log4j2.appender.out.type = RandomAccessFile
+log4j2.appender.out.name = File
+log4j2.appender.out.fileName=<%= @opencast_log_directory %>/opencast.log
+log4j2.appender.out.append = true
+log4j2.appender.out.layout.type = PatternLayout
+log4j2.appender.out.layout.pattern = ${log4j2.pattern}
 
-# Syslog
-log4j.appender.SYSLOG=org.apache.log4j.net.SyslogAppender
-log4j.appender.SYSLOG.SyslogHost=localhost
-log4j.appender.SYSLOG.Facility=local3
-log4j.appender.SYSLOG.Header=true
-log4j.appender.SYSLOG.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.SYSLOG.layout.ConversionPattern=opencast %p %t %c{1}.%M - %m %throwable%n
+# OSGi appender
+log4j2.appender.osgi.type = PaxOsgi
+log4j2.appender.osgi.name = PaxOsgi
+log4j2.appender.osgi.filter = *


### PR DESCRIPTION
Changes required for the OPC-139 OC LTI DeepLink editor tool and Opencast player LTI content item. These changes are related to the Karaf & lib upgrades from the OPC-139 pull (akin to updates from spring of OC7x). 

The worst part of this pull is the log changes. Adapting the DCE customizations to the log still need work as of July 25.

Companion OC https://bitbucket.org/hudcede/matterhorn-dce-fork/pull-requests/493