### PR TITLE
PSUPP-3145 test-local spring security auth redirect for playerold

### DIFF
--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -254,6 +254,8 @@
     <!-- #DCE OPC-54-test-local uses this link from the admin ui, which is a 
 	 redirect to Paella. This should come before /engage/** because the order matters! -->
     <sec:intercept-url pattern="/engage/player/watchAdminRedirect.html" method="GET" access="ROLE_ADMIN, ROLE_DCE_TEST_LOCAL" />
+    <!-- #DCE PSUPP-3145 test-local spring security auth redirect for playerold path when doing nginx redirect fallback -->
+    <sec:intercept-url pattern="/engage/playerold/watchAdminRedirect.html" method="GET" access="ROLE_ADMIN, ROLE_DCE_TEST_LOCAL" />
     <!-- #DCE KHD: MATT-2231 require login for annots summary (extra data auth on oauth performed in endpoint) -->
     <sec:intercept-url pattern="/engage/ui/annots/**" access="ROLE_ADMIN, ROLE_OAUTH_USER, ROLE_DCE_OC_SOCIAL_ADMIN" />
     <!-- Enable anonymous access to the engage player and the GET endpoints it requires -->


### PR DESCRIPTION
If doing nginx the redirect fallback, this pull provides spring security to the playerold admin redirect.