### PR TITLE
OPC-494 add thread to log by default

### DIFF
--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -7,7 +7,7 @@ color.debug = cyan
 color.trace = cyan
 
 # Common pattern layout for appenders
-log4j2.pattern =  %d{ISO8601} | %-5.5p | (%C{1}:%L) - %m%n
+log4j2.pattern =  %d{ISO8601} | %-5.5p | %tid | (%C{1}:%L) - %m%n
 
 # Root logger
 log4j2.rootLogger.level = WARN


### PR DESCRIPTION
This give log lines like the following. It addes 9-12 extra char per log.

2020-03-11T12:40:26,310 | INFO | th 209 | (Sched...
2020-03-11T12:40:26,311 | INFO | th 209 | (Sched...
2020-03-11T12:40:26,312 | INFO | th 209 | (Sched...