### PR TITLE
OPC-543 give DCE Producers rights to series property endpoint

### DIFF
--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -78,6 +78,10 @@
     <sec:intercept-url pattern="/admin-ng/series/*/access.json" method="GET" access="ROLE_ADMIN, ROLE_UI_SERIES_DETAILS_ACL_VIEW" />
     <sec:intercept-url pattern="/admin-ng/series/*/metadata.json" method="GET" access="ROLE_ADMIN, ROLE_UI_SERIES_DETAILS_METADATA_VIEW" />
     <sec:intercept-url pattern="/admin-ng/series/*/theme.json" method="GET" access="ROLE_ADMIN, ROLE_UI_SERIES_DETAILS_THEMES_VIEW" />
+    <!-- #DCE start OPC-543 -->
+    <sec:intercept-url pattern="/admin-ng/series/*/property/*" method="GET" access="ROLE_ADMIN, ROLE_DCE_TEST_LOCAL" />
+    <sec:intercept-url pattern="/admin-ng/series/*/property" method="POST" access="ROLE_ADMIN, ROLE_DCE_TEST_LOCAL" />
+    <!-- #DCE end OPC-543 -->
     <sec:intercept-url pattern="/admin-ng/server/servers.json" method="GET" access="ROLE_ADMIN, ROLE_UI_SERVERS_VIEW" />
     <sec:intercept-url pattern="/admin-ng/services/services.json" method="GET" access="ROLE_ADMIN, ROLE_UI_SERVICES_VIEW" />
     <sec:intercept-url pattern="/admin-ng/tasks/processing.json" method="GET" access="ROLE_ADMIN, ROLE_UI_TASKS_CREATE" />


### PR DESCRIPTION
Give DCE producers role group blanket rights to GET/POST on admin-ng series properties API.