### PR TITLE
MI-193: wipe pip cache directory used by the cloudwatch logs agent installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* MI-193: wipe `/root/.cache/pip/wheels` directory during cloudwatch log agent install
+
 ## v2.17.0 - 06/15/2020
 
 * OPC-543 admin-ng series property rights for producers

--- a/recipes/install-cwlogs.rb
+++ b/recipes/install-cwlogs.rb
@@ -25,6 +25,12 @@ directory '/opt/aws/cloudwatch' do
   recursive true
 end
 
+# wipe the pip cache directory to keep it from filling with wheel builds
+directory '/root/.cache/pip/wheels' do
+  action :delete
+  recursive true
+end
+
 remote_file '/opt/aws/cloudwatch/awslogs-agent-setup.py' do
   source %Q|https://s3.amazonaws.com/#{ shared_assets_bucket }/awslogs-agent-setup.py|
   mode '0755'
@@ -61,5 +67,3 @@ end
 if engage_node? || admin_node?
   configure_nginx_cloudwatch_logs
 end
-
-


### PR DESCRIPTION


The agent installer doesn't clean up the pip wheels it builds during the
install and they collect in this cache and are eating up disk space