### PR TITLE
OPC-580 Redirect http to https when host is *.harvard.edu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## TO BE RELEASED
 
-## v2.19.0 - 12/17/202
+## v2.20.0
+
+* OPC-580: redirect http requests to engage to https when host is *.harvard.edu
+
+## v2.19.0 - 12/17/2020
 
 * MI-193: wipe `/root/.cache/pip/wheels` directory during cloudwatch log agent install
 * OPC-577 remember-me bean for OC upstream security patches (companion OC patch)

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -691,17 +691,6 @@ module MhOpsworksRecipes
       end
     end
 
-    def configure_usertracking(current_deploy_root, user_tracking_authhost)
-      template %Q|#{current_deploy_root}/etc/services/org.opencastproject.usertracking.impl.UserTrackingServiceImpl.properties| do
-        source 'UserTrackingServiceImpl.properties.erb'
-        owner 'opencast'
-        group 'opencast'
-        variables({
-          user_tracking_authhost: user_tracking_authhost
-        })
-      end
-    end
-
     def download_episode_defaults_json_file(current_deploy_root)
       private_assets_bucket_name = node.fetch(:private_assets_bucket_name, 'default-private-bucket')
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -210,6 +210,11 @@ module MhOpsworksRecipes
       public_engage_hostname
     end
 
+    def get_public_engage_protocol
+      return node[:public_engage_protocol] if node[:public_engage_protocol]
+      'http'
+    end
+
     def get_public_engage_ip
       (private_engage_hostname, engage_attributes) = node[:opsworks][:layers][:engage][:instances].first
       engage_attributes[:ip]
@@ -663,13 +668,14 @@ module MhOpsworksRecipes
       files.fetch(node_profile.to_sym, [])
     end
 
-    def install_published_event_details_email(current_deploy_root, engage_hostname)
+    def install_published_event_details_email(current_deploy_root, engage_hostname, engage_protocol)
       template %Q|#{current_deploy_root}/etc/email/publishedEventDetails| do
         source 'publishedEventDetails.erb'
         owner 'opencast'
         group 'opencast'
         variables({
-          engage_hostname: engage_hostname
+          engage_hostname: engage_hostname,
+          engage_protocol: engage_protocol
         })
       end
     end
@@ -920,7 +926,7 @@ module MhOpsworksRecipes
       end
     end
 
-    def install_multitenancy_config(current_deploy_root, admin_hostname, engage_hostname)
+    def install_multitenancy_config(current_deploy_root, admin_hostname, engage_hostname, engage_protocol)
       template %Q|#{current_deploy_root}/etc/org.opencastproject.organization-mh_default_org.cfg| do
         source 'org.opencastproject.organization-mh_default_org.cfg.erb'
         owner 'opencast'
@@ -928,7 +934,8 @@ module MhOpsworksRecipes
         variables({
           hostname: admin_hostname,
           admin_hostname: admin_hostname,
-          engage_hostname: engage_hostname
+          engage_hostname: engage_hostname,
+          engage_protocol: engage_protocol
         })
       end
     end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -76,6 +76,7 @@ other_oc_preflocal_series = node.fetch(:other_oc_preflocal_series, ignore_flag)
 git_data = node[:deploy][:opencast][:scm]
 
 public_engage_hostname = get_public_engage_hostname
+public_engage_protocol = get_public_engage_protocol
 public_admin_hostname = get_public_admin_hostname_on_admin
 private_hostname = node[:opsworks][:instance][:private_dns_name]
 
@@ -121,7 +122,7 @@ deploy_revision "opencast" do
     install_init_scripts(most_recent_deploy, opencast_repo_root)
     install_opencast_log_configuration(most_recent_deploy)
     install_opencast_log_management
-    install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
+    install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname, public_engage_protocol)
     install_elasticsearch_index_config(most_recent_deploy,'adminui')
     install_elasticsearch_index_config(most_recent_deploy,'externalapi')
 #    remove_felix_fileinstall(most_recent_deploy)
@@ -147,7 +148,7 @@ deploy_revision "opencast" do
     unless ibm_watson_transcript_bucket.nil? or ibm_watson_transcript_bucket.empty?
       setup_transcript_result_sync_to_s3(shared_storage_root, ibm_watson_transcript_bucket)
     end
-    install_published_event_details_email(most_recent_deploy, public_engage_hostname)
+    install_published_event_details_email(most_recent_deploy, public_engage_hostname, public_engage_protocol)
 
     if using_local_distribution
       update_workflows_for_local_distribution(most_recent_deploy)
@@ -174,6 +175,7 @@ deploy_revision "opencast" do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_engage_hostname,
+        engage_protocol: public_engage_protocol,
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_monitor_url: live_monitor_url,
         job_maxload: nil,

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -18,9 +18,6 @@ private_hostname = node[:opsworks][:instance][:private_dns_name]
 
 
 ## all-in-one specific
-user_tracking_authhost = node.fetch(
-  :user_tracking_authhost, 'http://example.com'
-)
 
 using_local_distribution = is_using_local_distribution?
 
@@ -182,7 +179,6 @@ deploy_revision "opencast" do
 #    # all-in-one SPECIFIC
     initialize_database(most_recent_deploy)
 
-#    configure_usertracking(most_recent_deploy, user_tracking_authhost)
     install_aws_s3_distribution_service_config(most_recent_deploy, enable_s3, region, s3_distribution_bucket_name, s3_distribution_base_url)
     install_search_content_service_config(most_recent_deploy, search_content_enabled, region, s3_distribution_bucket_name, stack_name, search_content_index_url, search_content_lambda_name)
 #    install_opencast_images_properties(most_recent_deploy)

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -13,6 +13,7 @@ admin_user_info = get_admin_user_info
 stack_name = stack_shortname
 
 public_hostname = node[:opsworks][:instance][:public_dns_name]
+public_engage_protocol = get_public_engage_protocol
 private_hostname = node[:opsworks][:instance][:private_dns_name]
 
 
@@ -149,7 +150,7 @@ deploy_revision "opencast" do
     install_init_scripts(most_recent_deploy, opencast_repo_root)
     install_opencast_log_configuration(most_recent_deploy)
     install_opencast_log_management
-    install_multitenancy_config(most_recent_deploy, public_hostname, public_hostname)
+    install_multitenancy_config(most_recent_deploy, public_hostname, public_hostname, public_engage_protocol)
     install_elasticsearch_index_config(most_recent_deploy,'adminui')
     install_elasticsearch_index_config(most_recent_deploy,'externalapi')
 #    remove_felix_fileinstall(most_recent_deploy)
@@ -173,7 +174,7 @@ deploy_revision "opencast" do
     install_ibm_watson_transcription_service_config(most_recent_deploy, ibm_watson_url, ibm_watson_api_key, ibm_watson_username, ibm_watson_psw)
     # OPC-496
     install_adminui_tools_config(most_recent_deploy, zoom_ingester_url, zoom_ingester_api_key)
-    install_published_event_details_email(most_recent_deploy, public_hostname)
+    install_published_event_details_email(most_recent_deploy, public_hostname, public_engage_protocol)
     # f/OPC-344-notify-ca
     # External Capture Agent Sync service
     install_capture_agent_sync_config(most_recent_deploy)
@@ -208,6 +209,7 @@ deploy_revision "opencast" do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_hostname,
+        engage_protocol: public_engage_protocol,
         capture_agent_monitor_url: capture_agent_monitor_url,
         live_monitor_url: live_monitor_url,
         job_maxload: nil,

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -53,9 +53,6 @@ helix_sheet_id = helix_googlesheets_config[:helix_sheet_id]
 helix_email_enabled = helix_googlesheets_config[:change_notification_email_enabled]
 
 ## Engage specific
-user_tracking_authhost = node.fetch(
-  :user_tracking_authhost, 'http://example.com'
-)
 
 using_local_distribution = is_using_local_distribution?
 
@@ -133,7 +130,6 @@ deploy_revision "opencast" do
 
     # ENGAGE SPECIFIC
     set_service_registry_intervals(most_recent_deploy)
-#    configure_usertracking(most_recent_deploy, user_tracking_authhost)
     install_otherpubs_service_config(most_recent_deploy, opencast_repo_root, auth_host, other_oc_host, other_oc_prefother_series, other_oc_preflocal_series, bug_report_email)
     install_otherpubs_service_series_impl_config(most_recent_deploy)
     install_helix_googlesheets_service_config(most_recent_deploy, local_workspace_root,  helix_googlesheets_cred, helix_googlesheets_defaultdur_min, helix_enabled, helix_token, helix_sheet_id, helix_email_enabled)

--- a/recipes/deploy-engage.rb
+++ b/recipes/deploy-engage.rb
@@ -13,6 +13,7 @@ admin_user_info = get_admin_user_info
 stack_name = stack_shortname
 
 public_engage_hostname = get_public_engage_hostname_on_engage
+public_engage_protocol = get_public_engage_protocol
 private_hostname = node[:opsworks][:instance][:private_dns_name]
 private_admin_hostname = get_private_admin_hostname
 
@@ -116,7 +117,7 @@ deploy_revision "opencast" do
     install_init_scripts(most_recent_deploy, opencast_repo_root)
     install_opencast_log_configuration(most_recent_deploy)
     install_opencast_log_management
-    install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
+    install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname, public_engage_protocol)
 #    remove_felix_fileinstall(most_recent_deploy)
     install_smtp_config(most_recent_deploy)
 
@@ -157,6 +158,7 @@ deploy_revision "opencast" do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_engage_hostname,
+        engage_protocol: public_engage_protocol,
         capture_agent_monitor_url: capture_agent_monitor_url,
         job_maxload: nil,
         stack_name: stack_name,

--- a/recipes/deploy-worker.rb
+++ b/recipes/deploy-worker.rb
@@ -26,6 +26,7 @@ ldap_psw = ldap_conf[:pass]
 git_data = node[:deploy][:opencast][:scm]
 
 public_engage_hostname = get_public_engage_hostname
+public_engage_protocol = get_public_engage_protocol
 public_admin_hostname = get_public_admin_hostname
 private_hostname = node[:opsworks][:instance][:private_dns_name]
 private_admin_hostname = get_private_admin_hostname
@@ -70,7 +71,7 @@ deploy_revision "opencast" do
     install_init_scripts(most_recent_deploy, opencast_repo_root)
     install_opencast_log_configuration(most_recent_deploy)
     install_opencast_log_management
-    install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname)
+    install_multitenancy_config(most_recent_deploy, public_admin_hostname, public_engage_hostname, public_engage_protocol)
 #    remove_felix_fileinstall(most_recent_deploy)
 #    install_smtp_config(most_recent_deploy)
     if ldap_enabled
@@ -95,6 +96,7 @@ deploy_revision "opencast" do
         admin_auth: admin_user_info,
         database: database_connection,
         engage_hostname: public_engage_hostname,
+        engage_protocol: public_engage_protocol,
         capture_agent_monitor_url: capture_agent_monitor_url,
         job_maxload: 4,
         stack_name: stack_name,

--- a/templates/default/custom.properties.erb
+++ b/templates/default/custom.properties.erb
@@ -112,7 +112,7 @@ org.opencastproject.workflow.handler.workflow.ZipWorkflowOperationHandler.tmpdir
 # Comment for #DCE: After 2.x, this needs to be set to the internal publication channel i.e. 
 # http://ENGAGE/static. The S3 distributioni configuration now have a separate url where
 # we specify the bucket url or the cloudfront address.
-org.opencastproject.download.url=http://<%= @engage_hostname %>/static
+org.opencastproject.download.url=<%= @engage_protocol %>://<%= @engage_hostname %>/static
 
 # The directory to store media, metadata, and attachments for download from the engage tool
 org.opencastproject.download.directory=${org.opencastproject.shared_storage.dir}/downloads

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -13,6 +13,16 @@ proxy_buffers 16 16k;
 # Opencast throw jetty EofExceptions
 proxy_ignore_client_abort on;
 
+# All traffic that comes to http://SOMETHING.harvard.edu will be redirected to https.
+# The "harvard.edu" was used to exclude: the internal host name (used by Opencast job dispatching),
+# dev clusters that do not bother to set auth/ssl up, local vagrant.
+server {
+  listen 80;
+
+  server_name ~(.+).harvard.edu;
+  return 301 https://$1.harvard.edu$request_uri;
+}
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server ipv6only=on;

--- a/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
+++ b/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
@@ -127,7 +127,7 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Value: <a complete url with scheme and port>
 # Default: ${org.opencastproject.server.url}
 #
-prop.org.opencastproject.engage.ui.url=http://<%= @engage_hostname %>
+prop.org.opencastproject.engage.ui.url=<%= @engage_protocol %>://<%= @engage_hostname %>
 
 # Link to the RSS and atom feed base
 #

--- a/templates/default/publishedEventDetails.erb
+++ b/templates/default/publishedEventDetails.erb
@@ -12,8 +12,8 @@ Producer: ${catalogs['episode']['publisher']!'producer missing'}
 
 <#if catalogs['series']?has_content>
 <#if (catalogs['series']['identifier'])?matches("[0-9]{11}")>
-Publication listing page: http://<%= @engage_hostname %>/engage/ui/index.html#/${catalogs['series']['identifier'][0..3]}/${catalogs['series']['identifier'][4..5]}/${catalogs['series']['identifier'][6..10]}
+Publication listing page: <%= @engage_protocol %>://<%= @engage_hostname %>/engage/ui/index.html#/${catalogs['series']['identifier'][0..3]}/${catalogs['series']['identifier'][4..5]}/${catalogs['series']['identifier'][6..10]}
 <#else>
-Publication listing page (Non-DCE Series Identifier) : http://<%= @engage_hostname %>/engage/ui/publicationListing.shtml?seriesId=${catalogs['series']['identifier']}
+Publication listing page (Non-DCE Series Identifier) : <%= @engage_protocol %>://<%= @engage_hostname %>/engage/ui/publicationListing.shtml?seriesId=${catalogs['series']['identifier']}
 </#if>
 </#if>


### PR DESCRIPTION
This work is in preparation for the new auth because it's desirable to only allow the auth session cookie be sent with https requests only.
The idea is to only redirect http requests with a .harvard.edu name to https so that http can still be used for vagrant or a dev cluster that doesn't use auth. Note that the current auth already needs a .harvard.edu host name to work.
I've added a separate engage protocol config because engage host name is used in several places.
I've also updated all OC templates that refer to engage so that they use the correct protocol.
