### PR TITLE
OPC-608 Add configuration for porta series metadata update.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -294,6 +294,16 @@ module MhOpsworksRecipes
       )
     end
 
+    def get_porta_metadata_conf
+      node.fetch(
+        :porta_metadata_conf, {
+          enabled: false,
+          porta_url: '',
+          porta_api_key: ''
+        }
+      )
+    end
+
     def get_publish_1x_conf
       node.fetch(
         :publish_1x_conf, {
@@ -1211,6 +1221,19 @@ module MhOpsworksRecipes
           ldap_url: ldap_url,
           ldap_userdn: ldap_userdn,
           ldap_psw: ldap_psw
+        })
+      end
+    end
+
+    def install_porta_metadata_service(current_deploy_root, porta_url, porta_api_key, enabled = 'true')
+      template %Q|#{current_deploy_root}/etc/edu.harvard.dce.metadata.porta.PortaSeriesMetadataService.cfg| do
+        source 'edu.harvard.dce.metadata.porta.PortaSeriesMetadataService.cfg.erb'
+        owner 'opencast'
+        group 'opencast'
+        variables({
+          porta_url: porta_url,
+          porta_api_key: porta_api_key,
+          enabled: enabled 
         })
       end
     end

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -39,6 +39,12 @@ ibm_watson_username = ibm_watson_credentials[:user]
 ibm_watson_psw = ibm_watson_credentials[:pass]
 ibm_watson_transcript_bucket = get_ibm_watson_transcript_bucket_name
 
+# Push series metadata to porta system
+porta_conf = get_porta_metadata_conf
+porta_enabled = porta_conf[:enabled]
+porta_url = porta_conf[:porta_url]
+porta_api_key = porta_conf[:porta_api_key]
+
 # OPC-496 Zoom ingester config
 zoom_ingester_config = get_zoom_ingester_config
 zoom_ingester_url = zoom_ingester_config[:url]
@@ -154,6 +160,8 @@ deploy_revision "opencast" do
     # OPC-224 (only used during migration)
     install_ingest_1x_config(most_recent_deploy, s3_file_archive_bucket_name, admin_1x_url)
     install_ibm_watson_transcription_service_config(most_recent_deploy, ibm_watson_url, ibm_watson_api_key, ibm_watson_username, ibm_watson_psw)
+    # OPC-554 porta metadata service
+    install_porta_metadata_service(most_recent_deploy, porta_url, porta_api_key, porta_enabled)
     # OPC-496
     install_adminui_tools_config(most_recent_deploy, zoom_ingester_url, zoom_ingester_api_key)
     unless ibm_watson_transcript_bucket.nil? or ibm_watson_transcript_bucket.empty?

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -83,6 +83,12 @@ ldap_url = ldap_conf[:url]
 ldap_userdn = ldap_conf[:userdn]
 ldap_psw = ldap_conf[:pass]
 
+# Porta (push series metadata)
+porta_conf = get_porta_metadata_conf
+porta_enabled = porta_conf[:enabled]
+porta_url = porta_conf[porta_url]
+porta_api_key = porta_conf[:porta_api_key]
+
 # Publish to 1.x/migration settings
 publish_1x_conf = get_publish_1x_conf
 publish_1x_enabled = publish_1x_conf[:enabled]
@@ -161,6 +167,7 @@ deploy_revision "opencast" do
     install_auth_service(
       most_recent_deploy, auth_host, auth_redirect_location, auth_key, auth_activated, ldap_url, ldap_userdn, ldap_psw 
     )
+    install_porta_metadata_service(most_recent_deploy, porta_url, porta_api_key, porta_enabled)
     install_live_streaming_service_config(most_recent_deploy, live_stream_name, live_streaming_url, distribution)
     if ldap_enabled
       install_ldap_config(most_recent_deploy, ldap_url, ldap_userdn, ldap_psw)

--- a/templates/default/activemq.xml.erb
+++ b/templates/default/activemq.xml.erb
@@ -123,6 +123,7 @@
                   <queue physicalName="SERIES.Adminui" />
                   <queue physicalName="SERIES.Conductor" />
                   <queue physicalName="SERIES.Externalapi" />
+                  <queue physicalName="SERIES.MetadataListener" />
                 </forwardTo>
               </compositeQueue>
             </virtualDestinations>

--- a/templates/default/edu.harvard.dce.metadata.porta.PortaSeriesMetadataService.cfg.erb
+++ b/templates/default/edu.harvard.dce.metadata.porta.PortaSeriesMetadataService.cfg.erb
@@ -1,0 +1,12 @@
+# Indicates if this service is enabled
+enabled=<%= @enabled %>
+
+# The url where the porta api service is (course metadata updates) e.g. https://porta.dcex.harvard.edu
+api.base.url=<%= @porta_url %>
+
+# API key to be used when calling the porta api for course metadata updates 
+api.key=<%= @porta_api_key %>
+
+# The porta api path. Default: /api/v1/porta_api
+#api.path=/api/v1/porta_api
+


### PR DESCRIPTION
This is the configuration for the series metadata listener service in OC, which will push the relevant metadata changes in a course to porta.
It was previously part of the auth PR and, as such, had already been reviewed, but is now a separate PR because it will go to production for summer school.