### PR TITLE
Immersive Classroom Chat CORS updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* IC cors support, requires nginx update on engage
+
 ## v2.26.0 - 09/29/2021
 
 * *REQUIRES MANUAL RECIPE RUN* *REQUIRES EDITS TO CLUSTER CONFIG*

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -122,7 +122,7 @@ server {
   set $cors_vary "";
   set $cors_expose_headers "";
 
-  if ($http_origin ~* (https?://.*\.harvard.edu(:[0-9]+)?)) {
+  if ($http_origin ~* (https?://.*\.dcex.harvard.edu(:[0-9]+)?)) {
         set $cors_origin $http_origin;
         set $cors_cred   true;
         set $cors_header $http_access_control_request_headers;

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -107,9 +107,38 @@ server {
   client_max_body_size 102400m;
   gzip on;
 
-  add_header 'Access-Control-Allow-Origin' '*';
-  add_header 'Access-Control-Allow-Credentials' 'true';
-  add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+  # Avoid the if-is-evil-in-location nginx issue
+  # https://stackoverflow.com/questions/27955233/nginx-config-for-cors-add-header-directive-is-not-allowed
+  # Defaults for
+  # add_header 'Access-Control-Allow-Origin' '*';
+  # add_header 'Access-Control-Allow-Credentials' 'true';
+  # add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+  set $cors_origin "*";
+  set $cors_cred   "true";
+  set $cors_method "GET, OPTIONS";
+  # No defaults for these
+  set $cors_header "";
+  set $cors_xframe_option "";
+  set $cors_vary "";
+  set $cors_expose_headers "";
+
+  if ($http_origin ~* (https?://.*\.harvard.edu(:[0-9]+)?)) {
+        set $cors_origin $http_origin;
+        set $cors_cred   true;
+        set $cors_header $http_access_control_request_headers;
+        set $cors_method $http_access_control_request_method;
+        set $cors_xframe_option 'ALLOW FROM $http_origin';
+        set $cors_vary 'Origin';
+        set $cors_expose_headers 'Content-Length,Content-Range';
+  }
+  add_header Access-Control-Allow-Origin      $cors_origin;
+  add_header Access-Control-Allow-Credentials $cors_cred;
+  add_header Access-Control-Allow-Headers     $cors_header;
+  add_header Access-Control-Allow-Methods     $cors_method;
+  add_header X-Frame-Options                  $cors_xframe_option;
+  add_header Vary                             $cors_vary;
+  add_header Access-Control-Expose-Headers    $cors_expose_headers;
+  # -- End cors specific headers (nginx omits headers with empty value )-- #
 
   location /static {
     alias <%= @shared_storage_root %>/downloads;
@@ -128,44 +157,23 @@ server {
   }
 
   location / {
-    #
-    # CORS header support (OPC-621 Paella Embed API)
-    #
-    # One way to use this is by placing it into a file called "cors_support"
-    # under your Nginx configuration directory and placing the following
-    # statement inside your **location** block(s):
-    #
-    #   include cors_support;
-    #
-    # As of Nginx 1.7.5, add_header supports an "always" parameter which
-    # allows CORS to work if the backend returns 4xx or 5xx status code.
-    #
-    # For more information on CORS, please see: http://enable-cors.org/
-    # Forked from this Gist: https://gist.github.com/michiel/1064640
-    # Copied from https://gist.github.com/Stanback/7145487
-    #
-    set $cors '';
-    if ($http_origin ~* (https?://.*\.harvard.edu(:[0-9]+)?)) {
-      set $cors "true";
-    }
-    if ($cors = "true") {
-      add_header 'Access-Control-Allow-Origin' '$http_origin';
-      add_header 'X-Frame-Options' 'ALLOW FROM $http_origin';
-      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-      add_header 'Access-Control-Allow-Credentials' 'true';
-      add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Range';
-      add_header 'Vary' 'Origin';
-      add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-    }
-
     if ($request_method = 'OPTIONS') {
-      # Tell client that this pre-flight info is valid for 20 days
+      # Headers set inside an "if" need to be be within a location.
+      # Setting headers in this "if" remove headers set earlier.
+      # Add CORS headers onto the OPTIONS response
+      add_header Access-Control-Allow-Origin      $cors_origin;
+      add_header Access-Control-Allow-Credentials $cors_cred;
+      add_header Access-Control-Allow-Headers     $cors_header;
+      add_header Access-Control-Allow-Methods     $cors_method;
+      add_header X-Frame-Options                  $cors_xframe_option;
+      add_header Vary                             $cors_vary;
+      add_header Access-Control-Expose-Headers    $cors_expose_headers;
+      # Tell client that this pre-flight info is valid for 20 days.
       add_header 'Access-Control-Max-Age' 1728000;
       add_header 'Content-Type' 'text/plain charset=UTF-8';
       add_header 'Content-Length' 0;
       return 204;
     }
-
     proxy_pass http://127.0.0.1:<%= @opencast_backend_http_port %>;
   }
 }


### PR DESCRIPTION
This is to solve the issues of: 
1. only ONE if statement can set headers, because it removes all the previously set headers
2. It's safer to set headers outside of a If statement when ever possible
3. Once a header is set its hard to change, so it's better to use variables when possible to prevent duplicate headers

This pull has been tested in kdolan-oc-5x with immersive player CHAT request (with a companion update to the immersive-classroom code)