### PR TITLE
OPC-621 CORS support for Immersive Classroom Video Chat OPC-646

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TO BE RELEASED
 
+* IC cors support, requires nginx update on engage
 
 ## v2.27.1 - 11/01/2021
 

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -107,9 +107,38 @@ server {
   client_max_body_size 102400m;
   gzip on;
 
-  add_header 'Access-Control-Allow-Origin' '*';
-  add_header 'Access-Control-Allow-Credentials' 'true';
-  add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+  # Avoid the if-is-evil-in-location nginx issue
+  # https://stackoverflow.com/questions/27955233/nginx-config-for-cors-add-header-directive-is-not-allowed
+  # Defaults for
+  # add_header 'Access-Control-Allow-Origin' '*';
+  # add_header 'Access-Control-Allow-Credentials' 'true';
+  # add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+  set $cors_origin "*";
+  set $cors_cred   "true";
+  set $cors_method "GET, OPTIONS";
+  # No defaults for these
+  set $cors_header "";
+  set $cors_xframe_option "";
+  set $cors_vary "";
+  set $cors_expose_headers "";
+
+  if ($http_origin ~* (https?://.*\.dcex.harvard.edu(:[0-9]+)?)) {
+        set $cors_origin $http_origin;
+        set $cors_cred   true;
+        set $cors_header $http_access_control_request_headers;
+        set $cors_method $http_access_control_request_method;
+        set $cors_xframe_option 'ALLOW FROM $http_origin';
+        set $cors_vary 'Origin';
+        set $cors_expose_headers 'Content-Length,Content-Range';
+  }
+  add_header Access-Control-Allow-Origin      $cors_origin;
+  add_header Access-Control-Allow-Credentials $cors_cred;
+  add_header Access-Control-Allow-Headers     $cors_header;
+  add_header Access-Control-Allow-Methods     $cors_method;
+  add_header X-Frame-Options                  $cors_xframe_option;
+  add_header Vary                             $cors_vary;
+  add_header Access-Control-Expose-Headers    $cors_expose_headers;
+  # -- End cors specific headers (nginx omits headers with empty value )-- #
 
   location /static {
     alias <%= @shared_storage_root %>/downloads;
@@ -128,6 +157,23 @@ server {
   }
 
   location / {
+    if ($request_method = 'OPTIONS') {
+      # Headers set inside an "if" need to be be within a location.
+      # Setting headers in this "if" remove headers set earlier.
+      # Add CORS headers onto the OPTIONS response
+      add_header Access-Control-Allow-Origin      $cors_origin;
+      add_header Access-Control-Allow-Credentials $cors_cred;
+      add_header Access-Control-Allow-Headers     $cors_header;
+      add_header Access-Control-Allow-Methods     $cors_method;
+      add_header X-Frame-Options                  $cors_xframe_option;
+      add_header Vary                             $cors_vary;
+      add_header Access-Control-Expose-Headers    $cors_expose_headers;
+      # Tell client that this pre-flight info is valid for 20 days.
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain charset=UTF-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
     proxy_pass http://127.0.0.1:<%= @opencast_backend_http_port %>;
   }
 }


### PR DESCRIPTION
OPC-621 support for dce_porta cookies on GET from *.harvard.edu domains
OPC-621 moved if origin to the location section of server as required by nginx
Immersive Classroom Chat CORS - only ONE if statement can set headers, and existing ones need to be reset. Also, set defaults variables to prevent duplicate headers
IC-CORS peer reivew, reduce scope to *.dcex.harvard.edu vs *.harvard.edu