### PR TITLE
DEPLOY-64: enable TLS for postfix smtpd

### DIFF
--- a/recipes/install-oc-base-packages.rb
+++ b/recipes/install-oc-base-packages.rb
@@ -9,7 +9,7 @@ include_recipe "oc-opsworks-recipes::update-package-repo"
 # make sure we get this one from the epel repo or it will cause dep conflicts with tesseract
 install_package("libwebp", %Q|--disablerepo="*" --enablerepo="epel"|)
 
-packages = %Q|java-1.8.0-openjdk java-1.8.0-openjdk-devel mysql56 postfix tesseract|
+packages = %Q|java-1.8.0-openjdk java-1.8.0-openjdk-devel mysql56 postfix mailx tesseract|
 install_package(packages)
 
 # remove java-1.7 so that 1.8 becomes default

--- a/templates/default/postfix-main.cf.erb
+++ b/templates/default/postfix-main.cf.erb
@@ -1,12 +1,5 @@
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 
-
-# Debian specific:  Specifying a file name will cause the first
-# line of that file to be used as the name.  The Debian default
-# is /etc/mailname.
-#myorigin = /etc/mailname
-
-smtpd_banner =  ESMTP  (Ubuntu)
 biff = no
 
 # appending .domain is the MUA's job.
@@ -18,20 +11,21 @@ append_dot_mydomain = no
 readme_directory = no
 
 # TLS parameters
-smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
-smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+smtpd_tls_cert_file=<%= @postfix_cert_path %>
 smtpd_use_tls=yes
-smtpd_tls_session_cache_database = btree:/smtpd_scache
-smtp_tls_session_cache_database = btree:/smtp_scache
+smtpd_tls_loglevel = 1
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+mail_name = <%= @mail_name %>
 myhostname = <%= @hostname %>
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-myorigin = /etc/mailname
+myorigin = <%= @origin %>
 mydestination = <%= @hostname %>, localhost.localdomain, localhost
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
@@ -46,4 +40,4 @@ smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
 smtp_use_tls = yes
 smtp_tls_security_level = encrypt
 smtp_tls_note_starttls_offer = yes
-
+smtp_tls_loglevel = 1


### PR DESCRIPTION
- include the mailx package which provides the `mail` command for testing
- configure correct paths to postfix tls session cache dbs
- create a dummy key/cert file
- clean up some ubuntu-specific stuff from the postfix config
- turn on additional postfix tls logging