### PR TITLE
DEPLOY-76: allow use of prebuilt oc artifacts during deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* DEPLOY-76: allow use of prebuilt oc artifacts during deployment
+
 ## v3.0.5 - 03/22/2022
 
 * DEPLOY-75: fix `exec-dist-upgrade` recipe to use yum


### PR DESCRIPTION
- admin, engage and worker deploy recipes look for `oc_prebuilt_artifacts`
  block in the cluster config and, if enabled, fetch and extract
  tgz files from s3
- the opencast `revision` value in the cluster's app source
  configuration is used to build the s3 object url
- any `/` characters in the revision value are replaced with `-`
- the basic functionality of the `deploy_revision` chef resource is not
  modified; the opencast source is still pulled via git because we rely
  on the `before_symlink` callback to run and perform all of the
  installation, initialization and configuration tasks
