### PR TITLE
DEPLOY-77: updated buildspec for new prebuilt artifacts work

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,19 +1,40 @@
 version: 0.2
-
+env:
+  shell: bash
 phases:
   install:
+    runtime-versions:
+      ruby: "2.6"
     commands:
-      - echo Entered the install phase...
+      - printenv
       - gem install chef-config -v '< 16.5.77'
       - gem install mixlib-log -v '~> 2'
       - gem install berkshelf -v '~> 5.1'
   build:
     commands:
-      - echo Entered the build phase...
-      - export REVISION_ID=`echo $REVISION | sed 's/\//-/g'`
-      - berks package mh-opsworks-recipes-${REVISION_ID}.tar.gz
+      - echo Build started on `date`
+      - "# webhook triggered runs will have CODEBUILD_WEBHOOK_TRIGGER, e.g. `tag/[tag name]` or `branch/[branch name]`"
+      - "# manually triggered runs will only have CODEBUILD_SOURCE_VERSION"
+      - "# get the tag or branch name to use for the s3 object path"
+      - TRIGGER_BRANCH_OR_TAG=$CODEBUILD_WEBHOOK_TRIGGER
+      - if [ -z "$TRIGGER_BRANCH_OR_TAG" ]; then TRIGGER_BRANCH_OR_TAG="manual/${CODEBUILD_SOURCE_VERSION}"; fi
+      - "# - at this point TRIGGER_BRANCH_OR_TAG should look like `branch/[branch name]`, `tag/[tag name]`, or `manual/[branch or tag]`"
+      - "# - `cut` with `-f2-` will cut off the leading token (i.e. `branch/` or `tag/`) leaving other `/` characters intact"
+      - "# - `sed` will replace any remaning `/` with `-`"
+      - export TRIGGER_BRANCH_OR_TAG=$(echo $TRIGGER_BRANCH_OR_TAG | cut -d'/' -f2- | sed -e 's/\//-/g')
+      - echo trigger branch or tag "$TRIGGER_BRANCH_OR_TAG"
+      - ./bin/run_foodcritic.sh
+      - berks package mh-opsworks-recipes-${TRIGGER_BRANCH_OR_TAG}.tar.gz
+  post_build:
+    commands:
+      - bash -c "if [ "$CODEBUILD_BUILD_SUCCEEDING" == "0" ]; then exit 1; fi"
+      - echo Build completed on `date`
+    finally:
+      - payload={\"build_id\":\"$CODEBUILD_BUILD_ID\",\"build_url\":\"$CODEBUILD_BUILD_URL\",\"trigger_branch_or_tag\":\"$TRIGGER_BRANCH_OR_TAG\"}
+      - aws lambda invoke --function-name $NOTIFY_FUNCTION --invocation-type Event --payload $payload response.json
+      - cat response.json
 artifacts:
+  discard-paths: true
   files:
-    - mh-opsworks-recipes-${REVISION_ID}.tar.gz
-  discard-paths: yes
-
+    - "*.tar.gz"
+  name: cookbook/${TRIGGER_BRANCH_OR_TAG}

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1291,7 +1291,7 @@ module MhOpsworksRecipes
     def install_prebuilt_oc(bucket, revision, node_profile, current_deploy_root)
       archive_file = "#{node_profile.to_s}.tgz"
       revision_object_path = revision.to_s.gsub(/\//, "-")
-      s3_bucket_url = "s3://#{bucket}/#{revision_object_path}/#{archive_file}"
+      s3_bucket_url = "s3://#{bucket}/opencast/#{revision_object_path}/#{archive_file}"
 
       execute 'download prebuilt archive' do
         command %Q|/usr/local/bin/aws s3 cp #{s3_bucket_url} #{archive_file}|


### PR DESCRIPTION
The main change here is to the `buildspec.yml`. The new version manipulates the triggering branch/tag value into something it can use for labeling the package artifact objects and the resulting s3 object key. 

The 2nd, minor change is related to where the prebuilt opencast artifacts live in the artifact bucket.