### PR TITLE
OPC-719 Grant Producers access to 'Go to admin' button on Engage

### DIFF
--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -394,6 +394,8 @@
     <sec:intercept-url pattern="/admin-ng/" method="GET" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/admin-ng/index.html" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/index.html" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
+    <!-- OC Upstream #3959, #DCE OPC-719 Grant Producers access to "Go to admin" button from Engage -->
+    <sec:intercept-url pattern="/index.js" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/**" access="ROLE_ADMIN" />
 
     <!-- ############################# -->


### PR DESCRIPTION
OC Upstream #3959, #DCE Grant Producers access to 'Go to admin' button from Engage, by granting access to the  /index.js on Engage that calls components.json that contains the href for the 'Go to admin' button.

I'll make a QA to test on kdolan-11 and will comment on this ticket when tested.