### PR TITLE
OC11 move Admin UI global notifications from bottom-right to top-center

### DIFF
--- a/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
+++ b/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
@@ -300,7 +300,7 @@ prop.admin.shortcut.general.main_menu=m
 #
 # Default: bottom-right
 #
-#prop.admin.notification.position.global=bottom-right
+prop.admin.notification.position.global=top-center
 
 # If the preview mode in the video editor is enabled per default.
 #


### PR DESCRIPTION
Move default admin ui global notifications 