### PR TITLE
OPC-773 Fix bug where http connections were never released when downloading from S3

### DIFF
--- a/templates/default/custom.properties.erb
+++ b/templates/default/custom.properties.erb
@@ -165,16 +165,16 @@ org.opencastproject.workspace.cleanup.max.age=2592000
 # The scheduled period in seconds, at which a working file repository cleanup operation is performed.
 # 86400 seconds equals 24 hours.
 # Default value: -1 (Disable cleanup scheduler)
-#org.opencastproject.working.file.repository.cleanup.period=86400
+org.opencastproject.working.file.repository.cleanup.period=86400
 
 # The maximum age a file must reach in days before a deletion of the file in the workspace cleanup operation is
 # performed.
 # Default value: -1 (max age will never be reached)
-#org.opencastproject.working.file.repository.cleanup.max.age=100
+org.opencastproject.working.file.repository.cleanup.max.age=7
 
 # A comma separated lists of collections in the working file repository that shouldbe cleaned up.
 # Default value: Not provided (no collection will be cleaned up)
-#org.opencastproject.working.file.repository.cleanup.collections=failed.zips
+org.opencastproject.working.file.repository.cleanup.collections=asset_aws_s3
 
 
 ######### ACTIVE MQ BROKER #########

--- a/templates/default/opencast-setenv.erb
+++ b/templates/default/opencast-setenv.erb
@@ -31,8 +31,11 @@
 # export KARAF_BASE        # Karaf base folder
 # export KARAF_ETC         # Karaf etc  folder
 # export KARAF_OPTS        # Additional Karaf options
-# export KARAF_DEBUG       # Enable debug mode
 # export KARAF_REDIRECT    # Enable/set the std/err redirection when using bin/start
+#
+# Debug options
+# export KARAF_DEBUG       # Enable debug mode
+# export JAVA_DEBUG_PORT   # Set debug port (defaults to 5005)
 
 KARAF_DEBUG=<%= @java_debug_enabled %>
 LOGDIR=<%= @opencast_log_directory %>
@@ -43,6 +46,8 @@ GC=""
 #GC="${GC} -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintHeapAtGC"
 #GC="${GC} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=20 -XX:GCLogFileSize=32M -XX:+UseG1GC"
 
-export EXTRA_JAVA_OPTS="$GC -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
+# #DCE OPC-773 Publish AWS metrics
+export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dcom.amazonaws.sdk.enableDefaultMetrics $GC -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
 export JAVA_MAX_MEM=<%= @java_xmx_ram %>M
 export JAVA_HOME=<%= @java_home %>
+

--- a/templates/default/org.ops4j.pax.logging.cfg.erb
+++ b/templates/default/org.ops4j.pax.logging.cfg.erb
@@ -32,8 +32,6 @@ log4j2.logger.hudce.level = <%= @dce_log_level %>
 #log4j2.logger.ingest.level = DEBUG
 
 # OC11 Temporary
-log4j2.logger.security.name = org.opencastproject.kernel.security
-log4j2.logger.security.level = DEBUG
 log4j2.logger.hardlink.name = org.opencastproject.workspace.impl
 log4j2.logger.hardlink.level = TRACE 
 
@@ -44,6 +42,10 @@ log4j2.logger.felix.name = org.apache.felix
 log4j2.logger.felix.level = WARN
 log4j2.logger.cxf.name = org.apache.cxf
 log4j2.logger.cxf.level = WARN
+
+# Set aws logging to WARN
+log4j2.logger.awssdk.name = com.amazonaws
+log4j2.logger.awssdk.level = WARN
 
 # Helps to have these at DEBUG level or accessible to toggle to DEBUG as needed
 log4j2.logger.lti.name = org.opencastproject.lti.LtiServlet


### PR DESCRIPTION
- Enable aws sdk metrics.
- Add warn logging for aws.
- Configure aws s3 temp collection cleanup.