### PR TITLE
OPC-646 Immersive Classrooom integration stable 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TO BE RELEASED
 
+* IC: `*.dcex.harvard.edu` cors support, requires nginx update on engage
+* IC: OC admin ability to reference a specific IC server (for mpId trim updates)
+
 ## v4.4.0
 
 * Add stack name to org props in order to display it on the admin ui

--- a/recipes/configure-engage-nginx-proxy.rb
+++ b/recipes/configure-engage-nginx-proxy.rb
@@ -9,6 +9,9 @@ shared_storage_root = get_shared_storage_root
 
 public_engage_hostname = get_public_engage_hostname
 engage_whitelist = get_engage_admin_allowed_hosts
+# Use last 3 parts of Engage hostname domain for CORs domain check
+# Escape the 2 dots to use as literal dot chars in regex
+engage_domain_cors_regex = public_engage_hostname[/((?=.)(\w+))((?:.)(\w+)){2}\z/].gsub(/\./, "\\.")
 
 ssl_info = node.fetch(:ssl, get_dummy_cert)
 if cert_defined(ssl_info)
@@ -41,7 +44,8 @@ template 'proxy' do
     shared_storage_root: shared_storage_root,
     opencast_backend_http_port: 8080,
     certificate_exists: certificate_exists,
-    public_engage_hostname: public_engage_hostname
+    public_engage_hostname: public_engage_hostname,
+    engage_domain_cors_regex: engage_domain_cors_regex
   })
 end
 

--- a/recipes/deploy-admin.rb
+++ b/recipes/deploy-admin.rb
@@ -62,6 +62,10 @@ live_monitor_url = node.fetch(
   :live_monitor_url, 'rtmp://example.com/live/#{caName}-presenter.delivery.stream-960x270_1_200@xyz'
 )
 
+immersive_classroom_url = node.fetch(
+  :immersive_classroom_url, ''
+)
+
 live_streaming_url = get_live_streaming_url
 live_stream_name = get_live_stream_name
 distribution = using_local_distribution ? 'download' : 'aws.s3'
@@ -208,7 +212,8 @@ deploy_revision "opencast" do
         workspace_cleanup_period: 86400,
         activemq_bind_host: activemq_bind_host,
         distribution_type: distribution,
-        cas_service: cas_service
+        cas_service: cas_service,
+        immersive_classroom_url: immersive_classroom_url
       })
     end
   end

--- a/recipes/deploy-all-in-one.rb
+++ b/recipes/deploy-all-in-one.rb
@@ -74,6 +74,9 @@ capture_agent_monitor_url = node.fetch(
 
 production_management_email = node.fetch(
   :production_management_email, ''
+
+immersive_classroom_url = node.fetch(
+  :immersive_classroom_url, ''
 )
 
 live_monitor_url = node.fetch(
@@ -231,7 +234,8 @@ deploy_revision "opencast" do
         stack_name: stack_name,
         activemq_bind_host: activemq_bind_host,
         distribution_type: distribution,
-        production_management_email: production_management_email
+        production_management_email: production_management_email,
+        immersive_classroom_url: immersive_classroom_url
       })
     end
   end

--- a/templates/default/custom.properties.erb
+++ b/templates/default/custom.properties.erb
@@ -388,3 +388,6 @@ edu.harvard.dce.production.email=<%= @production_management_email %>
 edu.harvard.dce.cas.login.url=https://www.pin1.harvard.edu/cas/login
 edu.harvard.dce.cas.service=<%= @cas_service %>
 
+# Immersive classroom base url. Used to push a notification when a video is replaced by its trimmed version.
+edu.harvard.dce.immersive.classroom.url=<%= @immersive_classroom_url %>
+

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -107,9 +107,38 @@ server {
   client_max_body_size 102400m;
   gzip on;
 
-  add_header 'Access-Control-Allow-Origin' '*';
-  add_header 'Access-Control-Allow-Credentials' 'true';
-  add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+  # Avoid the if-is-evil-in-location nginx issue
+  # https://stackoverflow.com/questions/27955233/nginx-config-for-cors-add-header-directive-is-not-allowed
+  # Defaults for
+  # add_header 'Access-Control-Allow-Origin' '*';
+  # add_header 'Access-Control-Allow-Credentials' 'true';
+  # add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+  set $cors_origin "*";
+  set $cors_cred   "true";
+  set $cors_method "GET, OPTIONS";
+  # No defaults for these
+  set $cors_header "";
+  set $cors_xframe_option "";
+  set $cors_vary "";
+  set $cors_expose_headers "";
+
+  if ($http_origin ~* (https?://.*\.<%= @engage_domain_cors_regex %>(:[0-9]+)?)) {
+        set $cors_origin $http_origin;
+        set $cors_cred   true;
+        set $cors_header $http_access_control_request_headers;
+        set $cors_method $http_access_control_request_method;
+        set $cors_xframe_option 'ALLOW FROM $http_origin';
+        set $cors_vary 'Origin';
+        set $cors_expose_headers 'Content-Length,Content-Range';
+  }
+  add_header Access-Control-Allow-Origin      $cors_origin	always;
+  add_header Access-Control-Allow-Credentials $cors_cred	always;
+  add_header Access-Control-Allow-Headers     $cors_header	always;
+  add_header Access-Control-Allow-Methods     $cors_method	always;
+  add_header X-Frame-Options                  $cors_xframe_option always;
+  add_header Vary                             $cors_vary	always;
+  add_header Access-Control-Expose-Headers    $cors_expose_headers always;
+  # -- End cors specific headers (nginx omits headers with empty value )-- #
 
   location /static {
     alias <%= @shared_storage_root %>/downloads;
@@ -128,6 +157,23 @@ server {
   }
 
   location / {
+    if ($request_method = 'OPTIONS') {
+      # Headers set inside an "if" need to be be within a location.
+      # Setting headers in this "if" remove headers set earlier.
+      # Add CORS headers onto the OPTIONS response
+      add_header Access-Control-Allow-Origin      $cors_origin;
+      add_header Access-Control-Allow-Credentials $cors_cred;
+      add_header Access-Control-Allow-Headers     $cors_header;
+      add_header Access-Control-Allow-Methods     $cors_method;
+      add_header X-Frame-Options                  $cors_xframe_option;
+      add_header Vary                             $cors_vary;
+      add_header Access-Control-Expose-Headers    $cors_expose_headers;
+      # Tell client that this pre-flight info is valid for 20 days.
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain charset=UTF-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
     proxy_pass http://127.0.0.1:<%= @opencast_backend_http_port %>;
   }
 }


### PR DESCRIPTION
This is the IC-OC-Integration branch migrated to oc-master vs OC v11. 

It includes CORS support for  requests from *.harvard.edu addresses to enable the Porta Cookie to be sent in the Video Comments request from Immersive Classroom servers..  

The pull from https://github.com/harvard-dce/mh-opsworks-recipes/pull/259 was cherry-picked to f/OPC-646-IC-Integration-stable-11.