### PR TITLE
OPC-851 subdomain cors support from OC prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* IC: OPC-851 `*.dcex.harvard.edu` cors support from Prod OC Engage
+
 ## v4.4.1
 
 * IC: `*.dcex.harvard.edu` cors support, requires nginx update on engage

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -258,6 +258,15 @@ module MhOpsworksRecipes
       node.fetch(:vpn_ips, []) + ["127.0.0.1/32"]
     end
 
+    # Same subdomain CORS supprt
+    # If special public_engage_hostname_cors config exists, use that for subdomain CORS support
+    # Otherwise, use regular engage hostname for subdomain CORS support
+    def get_public_engage_hostname_cors
+      return node[:public_engage_hostname_cors] if node[:public_engage_hostname_cors]
+
+      get_public_engage_hostname
+    end
+
     def get_cloudfront_url
       node[:cloudfront_url]
     end

--- a/recipes/configure-engage-nginx-proxy.rb
+++ b/recipes/configure-engage-nginx-proxy.rb
@@ -8,10 +8,12 @@ include_recipe "oc-opsworks-recipes::install-nginx"
 shared_storage_root = get_shared_storage_root
 
 public_engage_hostname = get_public_engage_hostname
+public_engage_hostname_cors = get_public_engage_hostname_cors
+
 engage_whitelist = get_engage_admin_allowed_hosts
 # Use last 3 parts of Engage hostname domain for CORs domain check
 # Escape the 2 dots to use as literal dot chars in regex
-engage_domain_cors_regex = public_engage_hostname[/((?=.)(\w+))((?:.)(\w+)){2}\z/].gsub(/\./, "\\.")
+engage_domain_cors_regex = public_engage_hostname_cors[/((?=.)(\w+))((?:.)(\w+)){2}\z/].gsub(/\./, "\\.")
 
 ssl_info = node.fetch(:ssl, get_dummy_cert)
 if cert_defined(ssl_info)


### PR DESCRIPTION
I verified this pull on the OC immserive-5x (11x) dev cluster (opencast-dev-10.dcex.harvard.edu) See below. This small patch is an intermediary until the OC engage cluster rename goes through and can be left in place as fallback.

==============================
Adding new cluster config param:
```
         "public_engage_hostname": "opencast-dev-10.dcex.harvard.edu",
+        "public_engage_hostname_cors": "dummy-engage-for-test.abc.efg.edu",
         "public_engage_protocol": "https",
```
The deployed engage nginx recipe is as expected:
```
 ...
  if ($http_origin ~* (https?://.*\.abc\.efg\.edu(:[0-9]+)?)) {
        set $cors_origin $http_origin;
        ...
```

II. Without new config param 

```
         "public_engage_hostname": "opencast-dev-10.dcex.harvard.edu",
-        "public_engage_hostname_cors": "dummy-engage-for-test.abc.efg.edu",
+        "public_engage_hostname_cors_removed": "dummy-engage-for-test.abc.efg.edu",
         "public_engage_protocol": "https",
```
The deployed engage nginx recipe is as expected:
```
  if ($http_origin ~* (https?://.*\.dcex\.harvard\.edu(:[0-9]+)?)) {
        set $cors_origin $http_origin;
        set $cors_cred   true;
```

