### PR TITLE
OPC-682 paella7  paths plus the FileZip temp patch

### DIFF
--- a/templates/default/mh_default_org.xml.erb
+++ b/templates/default/mh_default_org.xml.erb
@@ -286,9 +286,13 @@
     <!-- anonymous access to user interface configuration -->
     <sec:intercept-url pattern="/ui/config/**" access="ROLE_ANONYMOUS" />
 
-    <!-- Paella player -->
+    <!-- Paella player 6 -->
     <sec:intercept-url pattern="/paella/ui/auth.html" access="ROLE_USER" />
     <sec:intercept-url pattern="/paella/ui/**" access="ROLE_ANONYMOUS" />
+
+    <!-- Paella player 7 -->
+    <sec:intercept-url pattern="/paella7/ui/auth.html" access="ROLE_USER" />
+    <sec:intercept-url pattern="/paella7/ui/**" access="ROLE_ANONYMOUS" />
 
     <!-- #DCE KHD: MATT-2231 require login for annots summary (extra data auth on oauth performed in endpoint) -->
     <sec:intercept-url pattern="/engage/ui/annots/**" access="ROLE_ADMIN, ROLE_OAUTH_USER, ROLE_DCE_OC_SOCIAL_ADMIN" />

--- a/templates/default/opencast-setenv.erb
+++ b/templates/default/opencast-setenv.erb
@@ -47,7 +47,7 @@ GC=""
 #GC="${GC} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=20 -XX:GCLogFileSize=32M -XX:+UseG1GC"
 
 # #DCE OPC-773 Publish AWS metrics
-export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dcom.amazonaws.sdk.enableDefaultMetrics $GC -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
+export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Djdk.util.zip.disableZip64ExtraFieldValidation=true -Dcom.amazonaws.sdk.enableDefaultMetrics $GC -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
 export JAVA_MAX_MEM=<%= @java_xmx_ram %>M
 export JAVA_HOME=<%= @java_home %>
 

--- a/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
+++ b/templates/default/org.opencastproject.organization-mh_default_org.cfg.erb
@@ -182,6 +182,7 @@ prop.adminui.user.external_role_display=false
 #
 # - theodul player: /engage/theodul/ui/core.html?id=#{id}
 # - paella  player: /paella/ui/watch.html?id=#{id}
+# - paella player 7 (beta): /paella7/ui/watch.html?id=#{id}
 #
 # Default: /paella/ui/watch.html?id=#{id}
 # #DCE re-using historic DCE path for paella player


### PR DESCRIPTION
OPC-682 paella7  configuration paths plus the FileZip temp patch. The configuration path etc/ui-config/mh_default_org/paella7 drives the paella7 player config. We were not using this for paella6, but we are for paella7