### PR TITLE
Upping the nginx `client_header_buffer_size` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TO BE RELEASED
 
+## v5.0.2 - 09/12/2023
+
+- Upping the engage nginx `large_client_header_buffers` setting (from 4 * 8k to
+  4 * 16k) to allow for big cookies and avoid HTTP 431/400 errors
+
 ## v5.0.1 - 09/08/2023
 
 - Fixing again the MemoryUsed metric; first try didn't end up with the correct modification

--- a/templates/default/engage-nginx-proxy-conf.erb
+++ b/templates/default/engage-nginx-proxy-conf.erb
@@ -13,6 +13,10 @@ proxy_buffers 16 16k;
 # Opencast throw jetty EofExceptions
 proxy_ignore_client_abort on;
 
+# prevents http 431/400 errors if e.g. cookies are too large;
+# default is 4 buffers of 8k
+large_client_header_buffers 4 16k;
+
 # All traffic that comes to http://SOMETHING.harvard.edu will be redirected to https.
 # The "harvard.edu" was used to exclude: the internal host name (used by Opencast job dispatching),
 # dev clusters that do not bother to set auth/ssl up, local vagrant.


### PR DESCRIPTION
Going from default 1k to 4k to allow for big cookies and avoid HTTP 431 errors