### PR TITLE
service config should use the symlinked path to the `current` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+- `opencast.service` file should use path to the current deployment (vs hardcoded release path)
+
 # v5.0.3 - 10/04/2023
 
 - Clean pip cache just like we do for yum

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -878,7 +878,7 @@ module MhOpsworksRecipes
         group 'root'
         mode '644'
         variables({
-          opencast_root: current_deploy_root
+          opencast_root: opencast_repo_root + '/current'
         })
         notifies :run, 'execute[systemd reload]', :immediately
       end

--- a/templates/default/opencast.service.erb
+++ b/templates/default/opencast.service.erb
@@ -7,8 +7,8 @@ After=network.target
 After=remote-fs.target
 
 [Service]
-ExecStart=/<%= @opencast_root %>/bin/start-opencast server
-ExecStop=/<%= @opencast_root %>/bin/stop-opencast
+ExecStart=<%= @opencast_root %>/bin/start-opencast server
+ExecStop=<%= @opencast_root %>/bin/stop-opencast
 Restart=always
 User=opencast
 


### PR DESCRIPTION
This is a laughably simple fix. I've tested it on rute-oc-5x-3 several times, going back and forth between new and previous releases. Also ensured that it doesn't cause issues when new instances are added and first brought online.