### PR TITLE
more build problems. let's try pinning the hittimes gem dependency.

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,7 +32,7 @@ phases:
       - echo Build completed on `date`
     finally:
       - payload={\"build_id\":\"$CODEBUILD_BUILD_ID\",\"build_url\":\"$CODEBUILD_BUILD_URL\",\"trigger_branch_or_tag\":\"$TRIGGER_BRANCH_OR_TAG\"}
-      - aws lambda invoke --function-name $NOTIFY_FUNCTION --invocation-type Event --payload $payload response.json
+      - aws lambda invoke --function-name $NOTIFY_FUNCTION --invocation-type Event --payload $payload --cli-binary-format raw-in-base64-out response.json
       - cat response.json
 artifacts:
   discard-paths: true

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,7 @@ phases:
       - printenv
       - gem install chef-config -v '< 16.5.77'
       - gem install mixlib-log -v '~> 2'
+      - gem install hitimes -v 2.0.0
       - gem install berkshelf -v '~> 5.1'
   build:
     commands:


### PR DESCRIPTION
New version of hitimes (v3.0.0) released on May 1st and requires ruby v3 (we still need 2.x), so we have to pin the latest hitimes gem that still supports ruby v2.